### PR TITLE
Define new 'group' object in ParameterJSO

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -370,7 +370,7 @@ body, table td, select, button {
    font-family: "FontAwesome";
    font-style: normal;
    content: "\f0d7"; /* fa-caret-down */
-   margin-right: 5px;
+   margin-right: 2.5px;
 }
 
 /* Separates parameter groups in the ParameterTable. */

--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -1,41 +1,26 @@
 /* 
-The MIT License (MIT)
-
-Copyright (c) 2014 mcflugen
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-/* 
    CSS rules for the WMT client.
    
    These rules are injected into the client through a GWT CssResource. See:
    http://www.gwtproject.org/doc/latest/DevGuideClientBundle.html#CssResource
-   
-   Color palette adapted from http://www.colourlovers.com/palette/292482/Terra.
 */
 
 /* Variables. */
-@def colorAbisso rgb(3,22,52);
-@def colorAcquaProfonda rgb(3,54,73);
-@def colorAcqua rgb(3,101,100);
-@def colorTerra rgb(205,179,128);
-@def colorTerraTerra rgb(232,221,203);
+
+/* A palette adapted from http://www.colourlovers.com/palette/292482/Terra. */
+/* @def colorDark rgb(3,22,52); */
+/* @def colorMediumDark rgb(3,54,73); */
+/* @def colorMedium rgb(3,101,100); */
+/* @def colorMediumLight rgb(205,179,128); */
+/* @def colorLight rgb(232,221,203); */
+
+@def colorDark rgb(26,51,81);
+@def colorMediumDark rgb(88,67,62);
+@def colorMedium rgb(109,99,97);
+@def colorMediumLight rgb(198,217,234);
+@def colorLight rgb(246,251,255);
 @def colorWarning rgb(203,73,54);
+
 @def fontFamily "Lucida Sans Unicode", "Lucida Grande", Sans-Serif;
 @def fontSmall 13px;
 @def fontMedium 14px;
@@ -53,7 +38,7 @@ body, table td, select, button {
 .wmt-SignInScreen {
   width: 100%;
   height: 100%;
-  background-color: colorAbisso;
+  background-color: colorDark;
 }
 .wmt-SignInScreenTitle {
   color: white;
@@ -62,7 +47,7 @@ body, table td, select, button {
   cursor: default;
 }
 .wmt-SignInScreenBox {
-  color: colorAcquaProfonda;
+  color: colorMediumDark;
   width: 80%;
   max-width: 400px;
   font-size: fontMedium;
@@ -71,13 +56,13 @@ body, table td, select, button {
 }
 .wmt-SignInScreenButton {
   color: white;
-  background-color: colorAcqua;
+  background-color: colorMedium;
   font-size: fontMedium;
   line-height: 1.25;
   padding: 6px 12px;
   cursor: pointer;
   margin-top: 14px;
-  border: 2px solid colorAcqua;
+  border: 2px solid colorMedium;
 }
 .wmt-SignInScreenError {
   color: colorWarning;
@@ -92,7 +77,7 @@ body, table td, select, button {
   cursor: pointer;
 }
 .wmt-SignInScreenLinks:hover {
-  color: colorTerra;
+  color: colorMediumLight;
 }
 .wmt-SignInScreenLinksInfo {
   color: white;
@@ -124,7 +109,7 @@ body, table td, select, button {
 */
 .wmt-NavBar {
   width: 100%;
-  background-color: colorAbisso;
+  background-color: colorDark;
 }
 .wmt-NavBarTitle {
   color: white;
@@ -141,13 +126,13 @@ body, table td, select, button {
 .wmt-UserPanelButton {
   display: inline-block;
   color: white;
-  background-color: colorAcqua;
+  background-color: colorMedium;
   font-size: fontMedium;
   line-height: 1.25;
   padding: 6px 12px;
   cursor: default;
   margin: 2px;
-  border: 2px solid colorAcqua;
+  border: 2px solid colorMedium;
 }
 .wmt-UserPanelButton-signOut {
   cursor: pointer;
@@ -160,7 +145,7 @@ body, table td, select, button {
 }
 .gwt-SplitLayoutPanel .gwt-SplitLayoutPanel-HDragger {
   background-color: white;
-  border-left: 1px solid colorAbisso;
+  border-left: 1px solid colorDark;
 }
 
 /*
@@ -181,22 +166,22 @@ body, table td, select, button {
 }
 .gwt-TabLayoutPanel .gwt-TabLayoutPanelTab-selected {
   font-weight: normal !important;
-  color: colorAbisso !important;
+  color: colorDark !important;
 }
 
 /*
    A consistent style for all buttons.
 */
 .wmt-Button, .wmt-ActionPanelButton {
-  color: colorAbisso;
-  background-color: colorTerraTerra;
+  color: colorDark;
+  background-color: colorLight;
   padding: 5px 7px;
-  border: 1px solid colorAcquaProfonda;
-  border-bottom: 1px solid colorAbisso;
+  border: 1px solid colorMediumDark;
+  border-bottom: 1px solid colorDark;
   cursor: pointer;
 }
 .wmt-Button:hover {
-  background-color: colorTerra;
+  background-color: colorMediumLight;
 }
 
 /*
@@ -210,7 +195,7 @@ body, table td, select, button {
   margin-right: 5px; /* provides inter-button spacing */
 }
 .wmt-ActionPanelButton:hover {
-  background-color: colorTerra;
+  background-color: colorMediumLight;
 }
 
 /*
@@ -227,9 +212,9 @@ body, table td, select, button {
 .wmt-ComponentCell {
   font-style: italic;
   text-align: center;
-  color: colorAbisso;
-  background-color: colorTerraTerra;
-  border: 2px solid colorAcquaProfonda;
+  color: colorDark;
+  background-color: colorLight;
+  border: 2px solid colorMediumDark;
   height: 60px;
   cursor: pointer;
 }
@@ -238,7 +223,7 @@ body, table td, select, button {
 .wmt-ComponentCell-connected {  
   font-style: normal;
   color: white;
-  background-color: colorAcqua;
+  background-color: colorMedium;
   position: relative;  
 }
 
@@ -250,7 +235,7 @@ body, table td, select, button {
   font-family: "FontAwesome";
   /* padding: 3px; */
   content: "\f0ad"; /* fa-wrench */
-  color: colorAbisso;
+  color: colorDark;
 }
 
 /* The name (port or component) shown inside the ComponentCell. */
@@ -271,7 +256,7 @@ body, table td, select, button {
    font-family: "FontAwesome";
    padding: 3px;
    content: "\f112"; /* fa-reply */
-   color: colorTerraTerra;
+   color: colorLight;
 }
 
 /* For the menuCell inside the ComponentCell. */
@@ -291,7 +276,7 @@ body, table td, select, button {
 
 /* Items shown in a WMT PopupPanel. */
 .wmt-PopupPanelItem, .wmt-ComponentSelectionMenuItem, .wmt-PopupPanelCheckBoxItem {
-  color: colorAcquaProfonda;
+  color: colorMediumDark;
   padding: 5px 40px 5px 5px;
 }
 .wmt-PopupPanelItem, .wmt-ComponentSelectionMenuItem {
@@ -299,7 +284,7 @@ body, table td, select, button {
   min-width: 150px;
 }
 .wmt-PopupPanelItem:hover {
-  background-color: colorTerraTerra;
+  background-color: colorLight;
 }
 .wmt-PopupPanelItem-disabled {
   color: lightgray;
@@ -311,14 +296,14 @@ body, table td, select, button {
   line-height: 2.0; /* Don't use :hover, set line-height. */
 }
 .wmt-PopupPanelCheckBoxItem-header {
-  color: colorAcqua;
+  color: colorMedium;
   font-weight: bold;
 }
 .wmt-PopupPanelCheckBoxItem-public:after {
   content: "public";
   font-variant: small-caps;
   float: right;
-  color: colorTerra;
+  color: colorMediumLight;
   margin-right: 1em;
 }
 
@@ -326,7 +311,7 @@ body, table td, select, button {
 .wmt-PopupPanelSeparator {
   width: 100%;
   height: 1px;
-  border-top: 1px solid colorTerraTerra;
+  border-top: 1px solid colorLight;
 }
 
 /* Items in the ComponentSelectionMenu. */
@@ -334,11 +319,11 @@ body, table td, select, button {
   font-family: "FontAwesome";
   font-style: normal;
   content: "\f013"; /* fa-cog */
-  color: colorAcquaProfonda;
+  color: colorMediumDark;
   margin-right: 0.5em;
 }
 .wmt-ComponentSelectionMenuItem:hover {
-  background-color: colorTerraTerra;
+  background-color: colorLight;
 }
 .wmt-ComponentSelectionMenuItem-missing {
   background-color: colorWarning;
@@ -347,15 +332,8 @@ body, table td, select, button {
 /* Text used in a parameter description. */
 .wmt-ParameterDescription {
    padding: 0 1em 0 1.5em;
-   color: colorAcquaProfonda;
+   color: colorMediumDark;
 }
-/*
-.wmt-ParameterDescription-group:before {
-   font-family: fontFamily;
-   content: "-";
-   margin-right: 5px;
-}
-*/
 .wmt-ParameterDescription-group {
    padding-left: 3.5em;
    vertical-align: middle;
@@ -363,12 +341,14 @@ body, table td, select, button {
 .wmt-ParameterDescription-groupLeader:before {
    font-family: "FontAwesome";
    font-style: normal;
+   color: colorDark;
    content: "\f0da"; /* fa-caret-right */
    margin-right: 5px;
 }
 .wmt-ParameterDescription-groupLeader-open:before {
    font-family: "FontAwesome";
    font-style: normal;
+   color: colorDark;
    content: "\f0d7"; /* fa-caret-down */
    margin-right: 2.5px;
 }
@@ -377,8 +357,8 @@ body, table td, select, button {
 .wmt-ParameterSeparator {
    font-style: oblique;
    padding: 10px 0 5px 0;
-   color: colorAcquaProfonda;
-   border: solid colorAcquaProfonda;
+   color: colorMediumDark;
+   border: solid colorMediumDark;
    border-width: 0 0 1px 0;
 }
 
@@ -394,11 +374,11 @@ body, table td, select, button {
 
 /* Used for all input widgets. ValueBoxen display numeric values. */
 .wmt-TextBoxen, .wmt-ValueBoxen {
-  color: colorAbisso;
-  background-color: colorTerraTerra;
+  color: colorDark;
+  background-color: colorLight;
   padding: 7px 4px;
-  border: 1px solid colorAcquaProfonda;
-  border-top: 1px solid colorAbisso;
+  border: 1px solid colorMediumDark;
+  border-top: 1px solid colorDark;
   font-size: fontSmall;
   width: 200px;
 }
@@ -415,10 +395,10 @@ body, table td, select, button {
   font-size: fontSmall;
   margin: 2px 0px;
   padding: 2px 0px; /* centers text on Firefox; does nothing on Chrome */
-  border: 1px solid colorAcquaProfonda; /* adding this changes the font?!? */
+  border: 1px solid colorMediumDark; /* adding this changes the font?!? */
   width: 210px; /* calculated by comparison with ValueBoxen */
   height: 32px;
-  background-color: colorTerraTerra;
+  background-color: colorLight;
   cursor: pointer;
 }
 .wmt-DroplistBox-upload {
@@ -427,13 +407,13 @@ body, table td, select, button {
 
 /* Styles for use by all DialogBoxes. */
 .wmt-DialogBox {
-  color: colorAbisso;
+  color: colorDark;
   background: white;
-  border: 2px solid colorAcquaProfonda;
+  border: 2px solid colorMediumDark;
   box-shadow: 2px 2px 1px lightgray;
 }
 .wmt-DialogBox .dialogTop {
-  background: colorAbisso;
+  background: colorDark;
   cursor: default;
 }
 .wmt-DialogBox .Caption {

--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -349,8 +349,15 @@ body, table td, select, button {
    padding: 0 1em 0 1.5em;
    color: colorAcquaProfonda;
 }
+.wmt-ParameterDescription-group:before {
+   font-family: "FontAwesome";
+   font-style: normal;
+   content: "\f101"; /* fa- */
+   margin-right: 5px;
+}
 .wmt-ParameterDescription-group {
-   padding-left: 3.5em
+   padding-left: 3.5em;
+   vertical-align: middle;
 }
 
 /* Separates parameter groups in the ParameterTable. */

--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -349,15 +349,28 @@ body, table td, select, button {
    padding: 0 1em 0 1.5em;
    color: colorAcquaProfonda;
 }
+/*
 .wmt-ParameterDescription-group:before {
-   font-family: "FontAwesome";
-   font-style: normal;
-   content: "\f101"; /* fa- */
+   font-family: fontFamily;
+   content: "-";
    margin-right: 5px;
 }
+*/
 .wmt-ParameterDescription-group {
    padding-left: 3.5em;
    vertical-align: middle;
+}
+.wmt-ParameterDescription-groupLeader:before {
+   font-family: "FontAwesome";
+   font-style: normal;
+   content: "\f0da"; /* fa-caret-right */
+   margin-right: 5px;
+}
+.wmt-ParameterDescription-groupLeader-open:before {
+   font-family: "FontAwesome";
+   font-style: normal;
+   content: "\f0d7"; /* fa-caret-down */
+   margin-right: 5px;
 }
 
 /* Separates parameter groups in the ParameterTable. */

--- a/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
@@ -55,8 +55,36 @@ public class ParameterJSO extends JavaScriptObject {
 		return (typeof this.visible == 'undefined') ? true : this.visible;
   }-*/;
 
-  public final native String getGroup() /*-{
-		return this.group;
+  /**
+   * A JSNI method for checking whether a ParameterJSO has a "group" attribute.
+   * Note that the return is a JS boolean, not a J Boolean.
+   */
+  public final native boolean hasGroup() /*-{
+		return 'group' in this;
+  }-*/;
+
+  /**
+   * A JSNI method to get the "name" attribute of a group, a String. If the
+   * group or the name doesn't exist, null is returned.
+   */
+  public final native String getGroupName() /*-{
+		return this.group && this.group.name || null;
+  }-*/;
+
+  /**
+   * A JSNI method to get the "leader" attribute of a group, a JS boolean. If
+   * the group or the leader doesn't exist, false is returned.
+   */
+  public final native boolean isGroupLeader() /*-{
+		return this.group && this.group.leader || false;
+  }-*/;
+
+  /**
+   * A JSNI method to get the number of members in a group, a JS int. If the
+   * group or the members atribute doesn't exist, 0 is returned.
+   */
+  public final native int nGroupMembers() /*-{
+		return this.group && this.group.members || 0;
   }-*/;
 
   /**

--- a/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
@@ -10,6 +10,7 @@ import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import edu.colorado.csdms.wmt.client.control.DataManager;
 import edu.colorado.csdms.wmt.client.data.ParameterJSO;
 import edu.colorado.csdms.wmt.client.ui.cell.DescriptionCell;
+import edu.colorado.csdms.wmt.client.ui.cell.SeparatorCell;
 import edu.colorado.csdms.wmt.client.ui.cell.ValueCell;
 import edu.colorado.csdms.wmt.client.ui.panel.ParameterActionPanel;
 
@@ -107,19 +108,12 @@ public class ParameterTable extends FlexTable {
       return;
     }
 
-    this.setWidget(tableRowIndex, 0, new DescriptionCell(parameter));
     if (parameter.getKey().matches("separator")) {
+      this.setWidget(tableRowIndex, 0, new SeparatorCell(parameter));
       this.getFlexCellFormatter().setColSpan(tableRowIndex, 0, 2);
-      this.getFlexCellFormatter().setStyleName(tableRowIndex, 0,
-          "wmt-ParameterSeparator");
     } else {
+      this.setWidget(tableRowIndex, 0, new DescriptionCell(parameter));
       this.setWidget(tableRowIndex, 1, new ValueCell(parameter));
-      this.getFlexCellFormatter().setStyleName(tableRowIndex, 0,
-          "wmt-ParameterDescription");
-      if (parameter.getGroup() != null) {
-        this.getFlexCellFormatter().addStyleName(tableRowIndex, 0,
-            "wmt-ParameterDescription-group");
-      }
       this.getFlexCellFormatter().setHorizontalAlignment(tableRowIndex, 1,
           HasHorizontalAlignment.ALIGN_RIGHT);
     }

--- a/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.cell;
 
 import com.google.gwt.user.client.ui.HTML;
@@ -51,5 +28,9 @@ public class DescriptionCell extends HTML {
     }
 
     this.setHTML(description);
+    this.setStylePrimaryName("wmt-ParameterDescription");
+    if (parameter.getGroup() != null) {
+      this.addStyleDependentName("group");
+    }
   }
 }

--- a/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
@@ -1,5 +1,7 @@
 package edu.colorado.csdms.wmt.client.ui.cell;
 
+import java.util.ArrayList;
+
 import com.google.gwt.user.client.ui.HTML;
 
 import edu.colorado.csdms.wmt.client.data.ParameterJSO;
@@ -11,6 +13,9 @@ import edu.colorado.csdms.wmt.client.data.ParameterJSO;
  * @author Mark Piper (mark.piper@colorado.edu)
  */
 public class DescriptionCell extends HTML {
+
+  private ArrayList<Integer> groupRows;
+  private Boolean groupRowsVisible = false;
 
   /**
    * Makes a DescriptionCell from the information contained in the input
@@ -29,8 +34,27 @@ public class DescriptionCell extends HTML {
 
     this.setHTML(description);
     this.setStylePrimaryName("wmt-ParameterDescription");
-    if (parameter.getGroup() != null) {
+    if ((parameter.hasGroup()) && (!parameter.isGroupLeader())) {
       this.addStyleDependentName("group");
     }
+    if (parameter.isGroupLeader()) {
+      this.addStyleDependentName("groupLeader");
+    }
+  }
+
+  public ArrayList<Integer> getGroupRows() {
+    return groupRows;
+  }
+
+  public void setGroupRows(ArrayList<Integer> groupRows) {
+    this.groupRows = groupRows;
+  }
+
+  public Boolean areGroupRowsVisible() {
+    return groupRowsVisible;
+  }
+
+  public void areGroupRowsVisible(Boolean groupRowsVisible) {
+    this.groupRowsVisible = groupRowsVisible;
   }
 }

--- a/src/edu/colorado/csdms/wmt/client/ui/cell/SeparatorCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/SeparatorCell.java
@@ -1,0 +1,26 @@
+package edu.colorado.csdms.wmt.client.ui.cell;
+
+import com.google.gwt.user.client.ui.HTML;
+
+import edu.colorado.csdms.wmt.client.data.ParameterJSO;
+
+/**
+ * A cell for separators between groups of parameters in a ParameterTable.
+ * 
+ * @author Mark Piper (mark.piper@colorado.edu)
+ */
+public class SeparatorCell extends HTML {
+
+  /**
+   * Makes a SeparatorCell from the information contained in the input
+   * ParameterJSO object.
+   * 
+   * @param parameter a ParameterJSO object
+   */
+  public SeparatorCell(ParameterJSO parameter) {
+
+    String description = parameter.getDescription();
+    this.setHTML(description);
+    this.setStylePrimaryName("wmt-ParameterSeparator");
+  }
+}

--- a/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
+++ b/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client;
 
 import org.junit.After;
@@ -47,7 +24,9 @@ public class ParameterJSOTest extends GWTTestCase {
   private String name;
   private String description;
   private Boolean visible;
-  private String group;
+  private String groupName;
+  private Boolean groupLeader;
+  private Integer groupMembers;
   private ValueJSO value;
 
   /**
@@ -61,19 +40,20 @@ public class ParameterJSOTest extends GWTTestCase {
   /**
    * A JSNI method that defines a fixture for the tests. Returns a
    * {@link ParameterJSO} object for testing.
-   *
-   * @param key
-   * @param name
-   * @param description
    */
   private native ParameterJSO testParameterJSO(String key, String name,
-      String description, String group, Boolean visible, ValueJSO value) /*-{
+      String description, String groupName, Boolean groupLeader,
+      Integer groupMembers, Boolean visible, ValueJSO value) /*-{
 		return {
 			"key" : key,
 			"name" : name,
 			"description" : description,
-			"group" : group,
-			"visible": visible,
+			"group" : {
+				"name" : groupName,
+				"leader" : groupLeader,
+				"members" : groupMembers
+			},
+			"visible" : visible,
 			"value" : value
 		};
   }-*/;
@@ -99,10 +79,14 @@ public class ParameterJSOTest extends GWTTestCase {
     key = "number_of_rows";
     name = "Number of rows";
     description = "Number of rows in the computational grid";
-    group = "parameter1";
+    groupName = "parameter1";
+    groupLeader = true;
+    groupMembers = 3;
     visible = true;
     value = testValueJSO();
-    jso = testParameterJSO(key, name, description, group, visible, value);
+    jso =
+        testParameterJSO(key, name, description, groupName, groupLeader,
+            groupMembers, visible, value);
   }
 
   @After
@@ -110,49 +94,46 @@ public class ParameterJSOTest extends GWTTestCase {
   protected void gwtTearDown() throws Exception {
   }
 
-  /*
-   * Test getting key.
-   */
   @Test
   public void testGetKey() {
     assertEquals(key, jso.getKey());
   }
 
-  /*
-   * Test getting name.
-   */
   @Test
   public void testGetName() {
     assertEquals(name, jso.getName());
   }
 
-  /*
-   * Test getting description.
-   */
   @Test
   public void testGetDescription() {
     assertEquals(description, jso.getDescription());
   }
 
-  /*
-   * Test getting group.
-   */
   @Test
-  public void testGetGroup() {
-    assertEquals(group, jso.getGroup());
+  public void testHasGroup() {
+    assertTrue(jso.hasGroup());
   }
 
-  /*
-   * Test getting visibility.
-   */
+  @Test
+  public void testGetGroupName() {
+    assertEquals(groupName, jso.getGroupName());
+  }
+
+  @Test
+  public void testIsGroupLeader() {
+    assertEquals(groupLeader, (Boolean) jso.isGroupLeader());
+  }
+
+  @Test
+  public void testNGroupMembers() {
+    assertEquals(groupMembers, (Integer) jso.nGroupMembers());
+  }
+
   @Test
   public void testIsVisible() {
     assertTrue(jso.isVisible());
   }
 
-  /*
-   * Test getting value.
-   */
   @Test
   public void testGetValue() {
     assertSame(value, jso.getValue());

--- a/war/data/vector_parameter_study.json
+++ b/war/data/vector_parameter_study.json
@@ -61,6 +61,11 @@
       "key":"parameter1",
       "name":"Parameter 1",
       "description":"Parameter name",
+      "group":{
+        "name":"parameter1",
+        "leader":true,
+        "members":2
+      },
       "value":{
         "type":"choice",
         "default":"starting_mean_annual_temperature",
@@ -80,7 +85,9 @@
       "key":"initial_point1",
       "name":"Parameter 1 initial value",
       "description":"initial value",
-      "group":"parameter1",
+      "group":{
+        "name":"parameter1"
+      },
       "value":{
         "type":"float",
         "default":0.0,
@@ -94,7 +101,9 @@
       "key":"final_point1",
       "name":"Parameter 1 final value",
       "description":"final value",
-      "group":"parameter1",
+      "group":{
+        "name":"parameter1"
+      },
       "value":{
         "type":"float",
         "default":0.0,
@@ -108,11 +117,16 @@
       "key":"parameter2",
       "name":"Parameter 2",
       "description":"Parameter name",
+      "group":{
+        "name":"parameter2",
+        "leader":true,
+        "members":2
+      },
       "value":{
         "type":"choice",
-        "default":"---",
+        "default":"",
         "choices":[
-          "---",
+          "",
           "starting_mean_annual_temperature",
           "standard_deviation_of_mean_annual_temperature",
           "total_annual_precipitation",
@@ -127,7 +141,10 @@
     {
       "key":"initial_point2",
       "name":"Parameter 2 initial value",
-      "description":"Initial value",
+      "description":"initial value",
+      "group":{
+        "name":"parameter2"
+      },
       "value":{
         "type":"float",
         "default":0.0,
@@ -140,7 +157,10 @@
     {
       "key":"final_point2",
       "name":"Parameter 2 final value",
-      "description":"Final value",
+      "description":"final value",
+      "group":{
+        "name":"parameter2"
+      },
       "value":{
         "type":"float",
         "default":0.0,
@@ -163,6 +183,11 @@
       "key":"response1",
       "name":"Output 1",
       "description":"Parameter name",
+      "group":{
+        "name":"response1",
+        "leader":true,
+        "members":1
+      },
       "value":{
         "type":"choice",
         "default":"channel_outflow_end_water__discharge",
@@ -176,7 +201,10 @@
     {
       "key":"statistic1",
       "name":"Statistic 1",
-      "description":"Statistic",
+      "description":"computed statistic",
+      "group":{
+        "name":"response1"
+      },
       "value":{
         "type":"choice",
         "default":"mean",
@@ -193,11 +221,16 @@
       "key":"response2",
       "name":"Output 2",
       "description":"Parameter name",
+      "group":{
+        "name":"response2",
+        "leader":true,
+        "members":1
+      },
       "value":{
         "type":"choice",
-        "default":"---",
+        "default":"<choose parameter>",
         "choices":[
-          "---",
+          "<choose parameter>",
           "channel_outflow_end_water__discharge",
           "channel_outflow_end_suspended_sediment__discharge",
           "channel_outflow_end_bed_load_sediment__mass_flow_rate"
@@ -207,7 +240,10 @@
     {
       "key":"statistic2",
       "name":"Statistic 2",
-      "description":"Statistic",
+      "description":"computed statistic",
+      "group":{
+        "name":"response1"
+      },
       "value":{
         "type":"choice",
         "default":"mean",

--- a/war/data/vector_parameter_study.json
+++ b/war/data/vector_parameter_study.json
@@ -79,7 +79,7 @@
     {
       "key":"initial_point1",
       "name":"Parameter 1 initial value",
-      "description":"- initial value",
+      "description":"initial value",
       "group":"parameter1",
       "value":{
         "type":"float",
@@ -93,7 +93,7 @@
     {
       "key":"final_point1",
       "name":"Parameter 1 final value",
-      "description":"- final value",
+      "description":"final value",
       "group":"parameter1",
       "value":{
         "type":"float",


### PR DESCRIPTION
The new `group` object is used to organize similar parameters. It has attributes `name` (String), `leader` (Boolean) and `members` (Integer).  Used in the `ParameterTable` to apply styles.

Also defined a new color palette and generalized the color palette names.