### PR TITLE
Add scrollbar to ComponentSelectionMenu

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/Constants.java
+++ b/src/edu/colorado/csdms/wmt/client/Constants.java
@@ -106,7 +106,7 @@ public class Constants {
   public static Double TAB_BAR_HEIGHT = 40.0;
 
   // Standard dimensions for PopupPanels.
-  public static String MENU_WIDTH = "220px"; // arbitrary, aesthetic
+  public static String MENU_WIDTH = "240px"; // arbitrary, aesthetic
   public static String MENU_HEIGHT = "20em";
 
   // The number of components displayed in a ComponentSelectionMenu before

--- a/src/edu/colorado/csdms/wmt/client/Constants.java
+++ b/src/edu/colorado/csdms/wmt/client/Constants.java
@@ -1,32 +1,8 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client;
 
 /**
  * A class that defines, as public static members, constants used in the WMT
- * client. In lieu of a configuration file, these constants can be edited 
- * before building the module.
+ * client.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */
@@ -132,6 +108,10 @@ public class Constants {
   // Standard dimensions for PopupPanels.
   public static String MENU_WIDTH = "220px"; // arbitrary, aesthetic
   public static String MENU_HEIGHT = "20em";
+
+  // The number of components displayed in a ComponentSelectionMenu before
+  // the scrollbar appears. (aesthetic)
+  public static Integer SCROLL_THRESHOLD = 10;
 
   // The default text displayed in the driver ComponentCell.
   public static String DRIVER = "driver";

--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -215,7 +215,7 @@ body, table td, select, button {
   color: colorDark;
   background-color: colorLight;
   border: 2px solid colorMediumDark;
-  height: 60px;
+  height: 70px;
   cursor: pointer;
 }
 
@@ -242,9 +242,7 @@ body, table td, select, button {
 .wmt-ComponentCell-NameCell {
   font-size: fontMedium;  
   text-align: center;
-  width: 100px;
-  max-width: 100px;
-  min-width: 100px;
+  width: 114px;
   margin-left: 5px;
 }
 

--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -272,10 +272,11 @@ body, table td, select, button {
   cursor: pointer;
 }
 
-/* Items shown in a WMT PopupPanel. */
+/* Items shown in a WMT PopupPanel. The padding on the right fills the
+   backgound color across the width of the panel. */
 .wmt-PopupPanelItem, .wmt-ComponentSelectionMenuItem, .wmt-PopupPanelCheckBoxItem {
   color: colorMediumDark;
-  padding: 5px 40px 5px 5px;
+  padding: 5px 36px 5px 5px;
 }
 .wmt-PopupPanelItem, .wmt-ComponentSelectionMenuItem {
   cursor: pointer;

--- a/src/edu/colorado/csdms/wmt/client/ui/menu/ComponentSelectionMenu.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/menu/ComponentSelectionMenu.java
@@ -78,6 +78,12 @@ public class ComponentSelectionMenu extends PopupPanel {
     item.setStyleName("wmt-ComponentSelectionMenuItem");
     item.addClickHandler(new ComponentSelectionHandler(componentId));
     componentSelectionPanel.insert(item, index);
+
+    // If the number of components in the componentSelectionPanel exceeds
+    // a threshold value, turn on the scrollPanel.
+    if (componentSelectionPanel.getWidgetCount() > Constants.SCROLL_THRESHOLD) {
+      scroller.setSize(Constants.MENU_WIDTH, Constants.MENU_HEIGHT);
+    }
   }
 
   /**
@@ -143,12 +149,6 @@ public class ComponentSelectionMenu extends PopupPanel {
       item.addStyleDependentName("missing");
       componentSelectionPanel.add(item);
     };
-    
-    // If the number of components in the componentSelectionPanel exceeds
-    // a threshold value, turn on the scrollPanel.
-    if (data.componentIdList.size() > Constants.SCROLL_THRESHOLD) {
-      scroller.setSize(Constants.MENU_WIDTH, Constants.MENU_HEIGHT);
-    }
   }
   
   /**

--- a/src/edu/colorado/csdms/wmt/client/ui/menu/ComponentSelectionMenu.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/menu/ComponentSelectionMenu.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.menu;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -28,6 +5,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.PopupPanel;
+import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 
 import edu.colorado.csdms.wmt.client.Constants;
@@ -36,8 +14,9 @@ import edu.colorado.csdms.wmt.client.ui.cell.ComponentCell;
 import edu.colorado.csdms.wmt.client.ui.handler.ComponentSelectionCommand;
 
 /**
- * A {@link PopupPanel} menu that shows a list of components. This is the
- * initial menu displayed in a {@link ComponentCell}.
+ * A {@link PopupPanel} menu that displays a scrollable list of components
+ * available in WMT. This is the initial menu displayed in a
+ * {@link ComponentCell}.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */
@@ -45,7 +24,8 @@ public class ComponentSelectionMenu extends PopupPanel {
 
   private DataManager data;
   private ComponentCell cell;
-  private VerticalPanel menu;
+  private VerticalPanel componentSelectionPanel;
+  private ScrollPanel scroller;
   private MenuItem componentItem;
 
   /**
@@ -56,15 +36,22 @@ public class ComponentSelectionMenu extends PopupPanel {
    * @param cell the {@link ComponentCell} this menu depends on
    */
   public ComponentSelectionMenu(DataManager data, ComponentCell cell) {
+
     super(true); // autohide
     this.data = data;
     this.cell = cell;
     this.setStyleName("wmt-PopupPanel");
     
     // A VerticalPanel for the menu items. (PopupPanels have only one child.)
-    menu = new VerticalPanel();
+    VerticalPanel menu = new VerticalPanel();
     this.add(menu);
-    
+
+    // Components are listed on the componentSelectionPanel, situated on a
+    // ScrollPanel.
+    componentSelectionPanel = new VerticalPanel();
+    scroller = new ScrollPanel(componentSelectionPanel);
+    menu.add(scroller);
+
     updateComponents(cell.getPortId());
   }
 
@@ -75,7 +62,7 @@ public class ComponentSelectionMenu extends PopupPanel {
    * @param componentId the id of the component to add to the menu
    */
   private void insertComponentMenuItem(String componentId) {
-    insertComponentMenuItem(componentId, menu.getWidgetCount());
+    insertComponentMenuItem(componentId, componentSelectionPanel.getWidgetCount());
   }
 
   /**
@@ -86,10 +73,11 @@ public class ComponentSelectionMenu extends PopupPanel {
    * @param index where to add the component to the menu
    */
   private void insertComponentMenuItem(String componentId, Integer index) {
+
     HTML item = new HTML(data.getComponent(componentId).getName());
     item.setStyleName("wmt-ComponentSelectionMenuItem");
     item.addClickHandler(new ComponentSelectionHandler(componentId));
-    menu.insert(item, index);
+    componentSelectionPanel.insert(item, index);
   }
 
   /**
@@ -100,12 +88,12 @@ public class ComponentSelectionMenu extends PopupPanel {
    */
   public void updateComponents(String portId) {
 
-    menu.clear();
+    componentSelectionPanel.clear();
 
     // Display a wait message in the componentMenu.
     if (portId.matches(Constants.DRIVER)) {
       HTML item = new HTML("Loading...");
-      menu.add(item);
+      componentSelectionPanel.add(item);
       return;
     }
 
@@ -148,13 +136,19 @@ public class ComponentSelectionMenu extends PopupPanel {
    * when their associated component is successfully loaded from the server.
    */
   public void initializeComponents() {
-    menu.clear();
+    componentSelectionPanel.clear();
     for (int i = 0; i < data.componentIdList.size(); i++) {
       HTML item = new HTML(data.componentIdList.get(i));
       item.setStyleName("wmt-ComponentSelectionMenuItem");
       item.addStyleDependentName("missing");
-      menu.add(item);
+      componentSelectionPanel.add(item);
     };
+    
+    // If the number of components in the componentSelectionPanel exceeds
+    // a threshold value, turn on the scrollPanel.
+    if (data.componentIdList.size() > Constants.SCROLL_THRESHOLD) {
+      scroller.setSize(Constants.MENU_WIDTH, Constants.MENU_HEIGHT);
+    }
   }
   
   /**
@@ -167,11 +161,11 @@ public class ComponentSelectionMenu extends PopupPanel {
    *          replace
    */
   public void replaceMenuItem(String componentId) {
-    for (int i = 0; i < menu.getWidgetCount(); i++) {
-      HTML currentItem = (HTML) menu.getWidget(i);
+    for (int i = 0; i < componentSelectionPanel.getWidgetCount(); i++) {
+      HTML currentItem = (HTML) componentSelectionPanel.getWidget(i);
       if (currentItem.getText().matches(componentId)) {
         insertComponentMenuItem(componentId, i);
-        menu.remove(currentItem);
+        componentSelectionPanel.remove(currentItem);
         return;
       }
     }


### PR DESCRIPTION
With the addition of TopoFlow, there are 38 components in WMT, causing the `ComponentSelectionMenu` to fall off the bottom of the screen. To keep this menu usable, I added a `ScrollPanel`. If more than a set number of components (currently 10) need to be displayed, a scrollbar is displayed.

Minor updates:

* Make `ComponentCell` taller and wider
* Make default `PopupPanel` wider to accommodate long component names.
