### PR TITLE
Display parameter units with brackets instead of parentheses

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
@@ -28,8 +28,8 @@ public class DescriptionCell extends HTML {
     String units = parameter.getValue().getUnits();
     String description = parameter.getDescription();
 
-    if (units != null) {
-      description += " (" + units + ")";
+    if (units != null)  {
+      description += " [" + units + "]";
     }
 
     this.setHTML(description);

--- a/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
@@ -28,7 +28,7 @@ public class DescriptionCell extends HTML {
     String units = parameter.getValue().getUnits();
     String description = parameter.getDescription();
 
-    if (units != null)  {
+    if ((units != null) && (!units.equals("-")))  {
       description += " [" + units + "]";
     }
 


### PR DESCRIPTION
Brackets are more commonly used than parentheses. 

Also, don't display units if the parameter has none.