### PR TITLE
Remove 'public' label when saving a model a user doesn't own

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/Constants.java
+++ b/src/edu/colorado/csdms/wmt/client/Constants.java
@@ -82,6 +82,10 @@ public class Constants {
   public static String DELETE_LABEL_ERR =
       "This label cannot be deleted because"
           + " it is not owned by the current user.";
+  public static String NOT_MODEL_OWNER =
+      "This model cannot be saved because the current user is not"
+          + " the model owner. Would you like to save a copy of"
+          + " this model with the current user as the owner?";
 
   // Questions
   public static String QUESTION_WMT = "What is WMT?";

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelSaveHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelSaveHandler.java
@@ -78,11 +78,7 @@ public class ModelActionPanelSaveHandler implements ClickHandler {
         // Don't allow a user to save a model that doesn't belong to them.
         // Give them the option to save a copy with their username.
         if (data.getMetadata().getOwner() != data.security.getWmtUsername()) {
-          String msg =
-              "This model cannot be saved because the current user is not"
-                  + " the model owner. Would you like to save a copy of"
-                  + " this model with the current user as the owner?";
-          Boolean saveCopy = Window.confirm(msg);
+          Boolean saveCopy = Window.confirm(Constants.NOT_MODEL_OWNER);
           if (saveCopy) {
             showSaveDialogBox(Constants.MODELS_NEW_PATH);
           }

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelSaveHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelSaveHandler.java
@@ -23,6 +23,8 @@
  */
 package edu.colorado.csdms.wmt.client.ui.handler;
 
+import java.util.Map;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyDownEvent;
@@ -31,6 +33,7 @@ import com.google.gwt.user.client.Window;
 import edu.colorado.csdms.wmt.client.Constants;
 import edu.colorado.csdms.wmt.client.control.DataManager;
 import edu.colorado.csdms.wmt.client.control.DataTransfer;
+import edu.colorado.csdms.wmt.client.data.LabelJSO;
 import edu.colorado.csdms.wmt.client.ui.dialog.SaveDialogBox;
 
 /**
@@ -76,10 +79,16 @@ public class ModelActionPanelSaveHandler implements ClickHandler {
       if (!data.modelIsSaved()) {
 
         // Don't allow a user to save a model that doesn't belong to them.
-        // Give them the option to save a copy with their username.
+        // Give them the option to save a copy with their username. If they so
+        // choose, be sure to deselect the 'public' label.
         if (data.getMetadata().getOwner() != data.security.getWmtUsername()) {
           Boolean saveCopy = Window.confirm(Constants.NOT_MODEL_OWNER);
           if (saveCopy) {
+            for (Map.Entry<String, LabelJSO> entry : data.modelLabels.entrySet()) {
+              if (entry.getKey().equals("public")) {
+                entry.getValue().isSelected(false);
+              }
+            }
             showSaveDialogBox(Constants.MODELS_NEW_PATH);
           }
         } else {


### PR DESCRIPTION
WMT prevents a user from saving a public model that they don't own. Instead, they're prompted to save (or "save as") the model under a different name (by default "copy" is appended to the name). This works as expected. However, the `public` label propagates to the saved copy. This is incorrect behavior which is fixed in this pull request.
