### PR TITLE
Add javadoc documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /www-test
 /test-classes
 /reports
+/docs
 /.gwt
 /.settings
 /war/wmt

--- a/build.xml
+++ b/build.xml
@@ -1,48 +1,50 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <project name="WMT" default="build" basedir=".">
-	<!-- Arguments to gwtc and devmode targets -->
 	<property name="gwt.args" value="" />
-
-	<!-- Removes javac message. See http://stackoverflow.com/a/8114557 -->
-	<presetdef name="javac">
-		<javac includeantruntime="false" />
-	</presetdef>
-
-	<!-- Access environment variables. See http://stackoverflow.com/a/18714086 -->
 	<property environment="env" />
-
-	<!-- Configure path to GWT SDK -->
-	<property name="gwt.sdk" location="${env.GWT_HOME}" />
+	<property name="gwt.sdk" location="${env.GWT_HOME}" /> 	<!-- Path to GWT -->
+    <property name="src.dir" value="src" />
+    <property name="test.dir" value="test" />
+	<property name="war.dir" value="war" />
+	<property name="war.file" value="wmt.war" />
+	<property name="war.lib.dir" value="${war.dir}/WEB-INF/lib" />
+    <property name="war.class.dir" value="${war.dir}/WEB-INF/classes" />
+	<property name="lib.dir" value="lib"/>
+    <property name="junit.jarfile" value="${lib.dir}/junit-4.11.jar"/>
+	<property name="package.name" value="edu.colorado.csdms.wmt"/>
 
 	<path id="project.class.path">
-		<pathelement location="war/WEB-INF/classes" />
+		<pathelement location="${war.class.dir}" />
 		<pathelement location="${gwt.sdk}/gwt-user.jar" />
 		<fileset dir="${gwt.sdk}" includes="gwt-dev*.jar" />
-		<!-- Add any additional non-server libs (such as JUnit) -->
-		<fileset dir="war/WEB-INF/lib" includes="**/*.jar" />
+		<fileset dir="${war.lib.dir}" includes="**/*.jar" />
 	</path>
 
 	<target name="libs" description="Copy libs to WEB-INF/lib">
-		<mkdir dir="war/WEB-INF/lib" />
-		<copy todir="war/WEB-INF/lib" file="${gwt.sdk}/gwt-servlet.jar" />
-		<copy todir="war/WEB-INF/lib" file="${gwt.sdk}/gwt-servlet-deps.jar" />
-		<!-- Add any additional server libs that need to be copied -->
+		<mkdir dir="${war.lib.dir}" />
+		<copy todir="${war.lib.dir}" file="${gwt.sdk}/gwt-servlet.jar" />
+		<copy todir="${war.lib.dir}" file="${gwt.sdk}/gwt-servlet-deps.jar" />
 	</target>
 
 	<target name="javac" depends="libs" description="Compile java source to bytecode">
-		<mkdir dir="war/WEB-INF/classes" />
-		<javac srcdir="src" includes="**" excludes="**/package-info.java" encoding="utf-8" destdir="war/WEB-INF/classes" source="1.5" target="1.5" nowarn="true" debug="true" debuglevel="lines,vars,source">
+		<mkdir dir="${war.class.dir}" />
+		<javac srcdir="${src.dir}" destdir="${war.class.dir}"
+			includes="**" excludes="**/package-info.java"
+			encoding="utf-8"  source="1.5" target="1.5"
+			nowarn="true" debug="true" debuglevel="lines,vars,source"
+			includeantruntime="false">
 			<classpath refid="project.class.path" />
 		</javac>
-		<copy todir="war/WEB-INF/classes">
-			<fileset dir="src" excludes="**/*.java" />
+		<copy todir="${war.class.dir}">
+			<fileset dir="${src.dir}" excludes="**/*.java" />
 		</copy>
+		<echo message="Compile complete." />
 	</target>
 
 	<target name="gwtc" depends="javac" description="GWT compile to JavaScript (production mode)">
 		<java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler">
 			<classpath>
-				<pathelement location="src" />
+				<pathelement location="${src.dir}" />
 				<path refid="project.class.path" />
 				<pathelement location="${gwt.sdk}/validation-api-1.0.0.GA.jar" />
 				<pathelement location="${gwt.sdk}/validation-api-1.0.0.GA-sources.jar" />
@@ -51,16 +53,16 @@
 			<jvmarg value="-Xmx256M" />
 			<arg line="-war" />
 			<arg value="war" />
-			<!-- Additional arguments like -style PRETTY or -logLevel DEBUG -->
 			<arg line="${gwt.args}" />
-			<arg value="edu.colorado.csdms.wmt.WMT" />
+			<arg value="${package.name}.WMT" />
 		</java>
+		<echo message="GWT compile complete." />
 	</target>
 
 	<target name="devmode" depends="javac" description="Run development mode">
 		<java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">
 			<classpath>
-				<pathelement location="src" />
+				<pathelement location="${src.dir}" />
 				<path refid="project.class.path" />
 				<pathelement location="${gwt.sdk}/validation-api-1.0.0.GA.jar" />
 				<pathelement location="${gwt.sdk}/validation-api-1.0.0.GA-sources.jar" />
@@ -70,15 +72,17 @@
 			<arg value="GWTWebApp.html" />
 			<arg line="-war" />
 			<arg value="war" />
-			<!-- Additional arguments like -style PRETTY or -logLevel DEBUG -->
 			<arg line="${gwt.args}" />
-			<arg value="edu.colorado.csdms.wmt.WMT" />
+			<arg value="${package.name}.WMT" />
 		</java>
 	</target>
 
 	<target name="javac.tests" depends="javac" description="Compiles test code">
-		<javac srcdir="test" includes="**" encoding="utf-8" source="1.5" target="1.5" nowarn="true" destdir="war/WEB-INF/classes" debug="true" debuglevel="lines,vars,source">
-			<classpath location="lib/junit-4.11.jar" />
+		<javac srcdir="${test.dir}" includes="**" encoding="utf-8" source="1.5"
+			target="1.5" nowarn="true" destdir="${war.class.dir}"
+			debug="true" debuglevel="lines,vars,source"
+			includeantruntime="false">
+			<classpath location="${junit.jarfile}" />
 			<classpath refid="project.class.path" />
 		</javac>
 	</target>
@@ -90,21 +94,22 @@
 			<sysproperty key="gwt.args" value="-standardsMode -logLevel WARN" />
 			<sysproperty key="java.awt.headless" value="true" />
 			<classpath>
-				<pathelement location="src" />
-				<pathelement location="test" />
+				<pathelement location="${src.dir}" />
+				<pathelement location="${test.dir}" />
 				<path refid="project.class.path" />
 				<pathelement location="${gwt.sdk}/validation-api-1.0.0.GA.jar" />
 				<pathelement location="${gwt.sdk}/validation-api-1.0.0.GA-sources.jar" />
-				<pathelement location="lib/junit-4.11.jar" />
+				<pathelement location="${junit.jarfile}" />
 			</classpath>
 			<batchtest todir="reports/htmlunit.dev">
-				<fileset dir="test">
+				<fileset dir="${test.dir}">
 					<include name="**/*Test.java" />
 				</fileset>
 			</batchtest>
 			<formatter type="plain" />
 			<formatter type="xml" />
 		</junit>
+		<echo message="Devmode tests complete." />
 	</target>
 
 	<target name="test.prod" depends="javac.tests" description="Run production mode tests">
@@ -114,12 +119,12 @@
 			<sysproperty key="gwt.args" value="-prod -standardsMode -logLevel WARN -standardsMode -out www-test" />
 			<sysproperty key="java.awt.headless" value="true" />
 			<classpath>
-				<pathelement location="src" />
-				<pathelement location="test" />
+				<pathelement location="${src.dir}" />
+				<pathelement location="${test.dir}" />
 				<path refid="project.class.path" />
 				<pathelement location="${gwt.sdk}/validation-api-1.0.0.GA.jar" />
 				<pathelement location="${gwt.sdk}/validation-api-1.0.0.GA-sources.jar" />
-				<pathelement location="lib/junit-4.11.jar" />
+				<pathelement location="${junit.jarfile}" />
 			</classpath>
 			<batchtest todir="reports/htmlunit.prod">
 				<fileset dir="test">
@@ -129,6 +134,7 @@
 			<formatter type="plain" />
 			<formatter type="xml" />
 		</junit>
+		<echo message="Production mode tests complete." />
 	</target>
 
 	<target name="test" description="Run development and production mode tests">
@@ -136,23 +142,24 @@
 		<antcall target="test.prod" />
 	</target>
 
-	<target name="hosted" depends="devmode" description="Run development mode (NOTE: the 'hosted' target is deprecated)" />
-
 	<target name="buildclean" description="Removes testing files from build of this project">
-		<delete dir="war/data" failonerror="false" />
-		<delete dir="war/save" failonerror="false" />
+		<delete dir="${war.dir}/data" failonerror="false" />
+		<delete dir="${war.dir}/save" failonerror="false" />
 	</target>
 
 	<target name="build" depends="gwtc" description="Build this project" />
 
 	<target name="war" depends="build" description="Create a war file">
-		<zip destfile="wmt.war" basedir="war" excludes="**/data/**, **/edu.colorado.csdms.wmt.WMT.JUnit/**, **/save/**" />
+		<zip destfile="${war.file}" basedir="${war.dir}"
+			excludes="**/data/**, **/edu.colorado.csdms.wmt.WMT.JUnit/**, **/save/**" />
+		<echo message="Warfile built." />
 	</target>
 
 	<target name="clean" description="Cleans this project">
-		<delete dir="war/WEB-INF/classes" failonerror="false" />
-		<delete dir="war/wmt" failonerror="false" />
-		<delete file="wmt.war" failonerror="false" />
+		<delete dir="${war.class.dir}" failonerror="false" />
+		<delete dir="${war.dir}/wmt" failonerror="false" />
+		<delete file="${war.file}" failonerror="false" />
+		<echo message="Cleanup complete." />
 	</target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -11,6 +11,7 @@
     <property name="war.class.dir" value="${war.dir}/WEB-INF/classes" />
 	<property name="lib.dir" value="lib"/>
     <property name="junit.jarfile" value="${lib.dir}/junit-4.11.jar"/>
+	<property name="docs.dir" value="docs" />
 	<property name="package.name" value="edu.colorado.csdms.wmt"/>
 
 	<path id="project.class.path">
@@ -155,10 +156,20 @@
 		<echo message="Warfile built." />
 	</target>
 
+	<target name="doc" description="Create javadoc documentation">
+		<javadoc packagenames="${package.name}.*" sourcepath="${src.dir}"
+		    destdir="${docs.dir}" author="true" version="true" use="true"
+		    overview="${src.dir}/overview.html"
+		    windowtitle="WMT-Client Documentation">
+		</javadoc>
+		<echo message="Docs done." />
+	</target>
+
 	<target name="clean" description="Cleans this project">
 		<delete dir="${war.class.dir}" failonerror="false" />
 		<delete dir="${war.dir}/wmt" failonerror="false" />
 		<delete file="${war.file}" failonerror="false" />
+		<delete dir="${doc.dir}" />
 		<echo message="Cleanup complete." />
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -159,7 +159,8 @@
 	<target name="doc" description="Create javadoc documentation">
 		<javadoc packagenames="${package.name}.*" sourcepath="${src.dir}"
 		    destdir="${docs.dir}" author="true" version="true" use="true"
-		    overview="${src.dir}/overview.html"
+		    classpathref="project.class.path"
+			overview="${src.dir}/overview.html"
 		    windowtitle="WMT-Client Documentation">
 		</javadoc>
 		<echo message="Docs done." />

--- a/src/edu/colorado/csdms/wmt/client/Resources.java
+++ b/src/edu/colorado/csdms/wmt/client/Resources.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client;
 
 import com.google.gwt.core.client.GWT;
@@ -28,15 +5,18 @@ import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 
 /**
- * Creates a new {@link ClientBundle} to define custom CSS rules for WMT.
+ * Creates a new {@link ClientBundle} to define custom CSS rules for WMT. See <a
+ * href=
+ * "http://www.gwtproject.org/doc/latest/DevGuideClientBundle.html#CssResource"
+ * >DevGuideClientBundle</a>.
  * 
- * @see http://www.gwtproject.org/doc/latest/DevGuideClientBundle.html#CssResource
+ * @see CssResource
  * @author Mark Piper (mark.piper@colorado.edu)
  */
 public interface Resources extends ClientBundle {
 
   public static final Resources INSTANCE = GWT.create(Resources.class);
-  
+
   @Source("WMT.css")
   @CssResource.NotStrict
   CssResource css();

--- a/src/edu/colorado/csdms/wmt/client/control/DataManager.java
+++ b/src/edu/colorado/csdms/wmt/client/control/DataManager.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.control;
 
 import java.util.ArrayList;
@@ -56,21 +33,21 @@ public class DataManager {
   // The initial sign-in screen. Either this or the Perspective are always
   // attached to the RootLayoutPanel of the application.
   private SignInScreen signInScreen;
-  
-  // Get the state of UI elements through the Perspective. 
+
+  // Get the state of UI elements through the Perspective.
   private Perspective perspective;
 
   private List<ComponentJSO> components; // "class" components
   private List<ComponentJSO> modelComponents; // "instance" components
   private ComponentCell componentShowingParameters;
-  
+
   private ModelJSO model;
   private ModelMetadataJSO metadata;
   private Boolean modelIsSaved = false;
   private String modelString; // stringified JSON
-  
+
   private String simulationId; // the uuid of a submitted run
-  
+
   // Experiment with public members, for convenience.
   public Security security;
   public ConfigurationJSO config;
@@ -117,7 +94,7 @@ public class DataManager {
   public void showWaitCursor() {
     perspective.getElement().getStyle().setCursor(Cursor.WAIT);
   }
-  
+
   /**
    * Shows the default cursor.
    */
@@ -150,8 +127,8 @@ public class DataManager {
   }
 
   /**
-   * A convenience method that returns the {@link ComponentJSO} object
-   * matching the given component id.
+   * A convenience method that returns the {@link ComponentJSO} object matching
+   * the given component id.
    * 
    * @param componentId the id of the desired component, a String
    */
@@ -204,8 +181,8 @@ public class DataManager {
   }
 
   /**
-   * A convenience method that returns the {@link ComponentJSO} object
-   * matching the given model component id, or null if no match is found.
+   * A convenience method that returns the {@link ComponentJSO} object matching
+   * the given model component id, or null if no match is found.
    * <p>
    * Compare with {@link #getComponent(String)} for "class" components.
    * 
@@ -267,7 +244,8 @@ public class DataManager {
 
   /**
    * Replaces <em>all</em> of the model components with copies of the (class)
-   * components using {@link DataTransfer#copy()}.
+   * components using
+   * {@link DataTransfer#copy(com.google.gwt.core.client.JavaScriptObject)}.
    */
   public void resetModelComponents() {
     for (int i = 0; i < modelComponents.size(); i++) {
@@ -290,7 +268,7 @@ public class DataManager {
    * Sets an ArrayList of ComponentJSOs representing <em>all</em> the model
    * components.
    * 
-   * @param components all your components are belong to us
+   * @param modelComponents all your components are belong to us
    */
   public void setModelComponents(List<ComponentJSO> modelComponents) {
     this.modelComponents = modelComponents;
@@ -314,8 +292,7 @@ public class DataManager {
   }
 
   /**
-   * Returns the ModelMetadataJSO object used to store the metadata for a
-   * model.
+   * Returns the ModelMetadataJSO object used to store the metadata for a model.
    */
   public ModelMetadataJSO getMetadata() {
     return metadata;
@@ -389,7 +366,7 @@ public class DataManager {
     modelIsSaved(state);
     perspective.setModelPanelTitle();
   }
-  
+
   /**
    * Gets the stringified model JSON created by {@link #serialize()}.
    */
@@ -423,7 +400,7 @@ public class DataManager {
   }
 
   /**
-   * Returns the {@link ComponentCell} that's currently displaying its 
+   * Returns the {@link ComponentCell} that's currently displaying its
    * parameters in the Parameters view.
    */
   public ComponentCell getShowingParameters() {
@@ -431,7 +408,7 @@ public class DataManager {
   }
 
   /**
-   * Sets the {@link ComponentCell} that's showing its parameters in the 
+   * Sets the {@link ComponentCell} that's showing its parameters in the
    * Parameters view.
    * 
    * @param componentShowingParameters
@@ -442,10 +419,10 @@ public class DataManager {
   }
 
   /**
-   * Translates the model displayed in WMT into a {@link ModelJSO} object,
-   * which completely describes the state of the model. This object is
-   * converted to a string (with {@link DataTransfer#stringify()}) which can
-   * be uploaded to a server.
+   * Translates the model displayed in WMT into a {@link ModelJSO} object, which
+   * completely describes the state of the model. This object is converted to a
+   * string (with {@link DataTransfer#stringify(Object)}) which can be uploaded
+   * to a server.
    */
   public void serialize() {
     ModelSerializer serializer = new ModelSerializer(this);
@@ -454,9 +431,9 @@ public class DataManager {
   }
 
   /**
-   * Extracts the information contained in the {@link ModelJSO} object
-   * returned from opening a model (model menu > "Open Model...") and uses it
-   * to populate the {@link ModelTree}.
+   * Extracts the information contained in the {@link ModelJSO} object returned
+   * from opening a model (model menu > "Open Model...") and uses it to populate
+   * the {@link ModelTree}.
    */
   public void deserialize() {
     perspective.setModelPanelTitle();

--- a/src/edu/colorado/csdms/wmt/client/control/DataTransfer.java
+++ b/src/edu/colorado/csdms/wmt/client/control/DataTransfer.java
@@ -71,10 +71,11 @@ public class DataTransfer {
 
   /**
    * A JSNI method for creating a String from a JavaScriptObject.
+   * <p>
+   * See <a href=
+   * "http://stackoverflow.com/questions/4872770/excluding-gwt-objectid-from-json-stringifyjso-in-devmode"
+   * >this</a> discussion of '__gwt_ObjectId'.
    * 
-   * @see <a
-   *      href="http://stackoverflow.com/questions/4872770/excluding-gwt-objectid-from-json-stringifyjso-in-devmode">this</a>
-   *      discussion of '__gwt_ObjectId'
    * @param jso a JavaScriptObject
    * @return a String representation of the JavaScriptObject
    */
@@ -90,13 +91,12 @@ public class DataTransfer {
   /**
    * A JSNI method for evaluating JSONs. This is a generic method. It returns a
    * JavaScript object of the type denoted by the type parameter T.
-   * 
-   * @see <a
-   *      href="http://docs.oracle.com/javase/tutorial/extra/generics/methods.html">Generic
-   *      Methods</a>
-   * @see <a
-   *      href="http://stackoverflow.com/questions/1843343/json-parse-vs-eval">JSON.parse
-   *      vs. eval()</a>
+   * <p>
+   * See <a
+   * href="http://docs.oracle.com/javase/tutorial/extra/generics/methods.html"
+   * >Generic Methods</a> and <a
+   * href="http://stackoverflow.com/questions/1843343/json-parse-vs-eval"
+   * >JSON.parse vs. eval()</a>.
    * 
    * @param jsonStr a trusted String
    * @return a JavaScriptObject that can be cast to an overlay type
@@ -122,12 +122,13 @@ public class DataTransfer {
    * A recursive JSNI method for making a deep copy of an input
    * JavaScriptObject. This is the private implementation of
    * {@link #copy(JavaScriptObject)}.
+   * <p>
+   * See <a
+   * href="http://stackoverflow.com/questions/4730463/gwt-overlay-deep-copy"
+   * >This</a> example code was very helpful (thanks to the author, <a
+   * href="http://stackoverflow.com/users/247462/javier-ferrero">Javier
+   * Ferrero</a>!)
    * 
-   * @see <a
-   *      href="http://stackoverflow.com/questions/4730463/gwt-overlay-deep-copy"
-   *      >This</a> example code was very helpful (thanks to the author, <a
-   *      href="http://stackoverflow.com/users/247462/javier-ferrero">Javier
-   *      Ferrero</a>!)
    * @param obj
    */
   private static native JavaScriptObject copyImpl(JavaScriptObject obj) /*-{
@@ -205,12 +206,12 @@ public class DataTransfer {
               GWT.log(rtxt);
               ConfigurationJSO jso = parse(rtxt);
               data.config = jso;
-              
-              // Once the location of the API has been determined, retrieve 
+
+              // Once the location of the API has been determined, retrieve
               // (asynchronously) and store the list of available components
-              // and models. Note that when #getComponentList completes, it 
+              // and models. Note that when #getComponentList completes, it
               // immediately starts pulling component data from the server with
-              // calls to #getComponent. Asynchronous requests are cool!              
+              // calls to #getComponent. Asynchronous requests are cool!
               getComponentList(data);
               getModelList(data);
             }
@@ -224,7 +225,7 @@ public class DataTransfer {
       Window.alert(Constants.REQUEST_ERR_MSG + e.getMessage());
     }
   }
-  
+
   /**
    * Makes an asynchronous HTTPS POST request to create a new user login to WMT.
    * 
@@ -744,7 +745,7 @@ public class DataTransfer {
     entries.put("model", modelId.toString()); // type="text" in API
     entries.put("tag", labelId.toString());
     String queryString = buildQueryString(entries);
-    
+
     try {
       builder.setHeader("Content-Type", "application/x-www-form-urlencoded");
       @SuppressWarnings("unused")
@@ -755,7 +756,7 @@ public class DataTransfer {
       Window.alert(Constants.REQUEST_ERR_MSG + e.getMessage());
     }
   }
-  
+
   /**
    * Makes an asynchronous HTTPS GET request to query what models use the given
    * labels, input as an List of Integer ids.
@@ -791,11 +792,11 @@ public class DataTransfer {
   }
 
   /**
-   * Makes an asynchronous HTTPS GET request to query what models use the given
-   * labels, input as an List of Integer ids.
+   * Makes an asynchronous HTTPS GET request to query what labels the models 
+   * has, given the model identifier. 
    * 
    * @param data the DataManager object for the WMT session
-   * @param labelIds a List of Integer label ids
+   * @param modelId the id of the model
    */
   public static void getModelLabels(DataManager data, Integer modelId) {
 
@@ -845,7 +846,7 @@ public class DataTransfer {
       // Replace the sign-in screen with the WMT GUI.
       RootLayoutPanel.get().remove(data.getSignInScreen());
       RootLayoutPanel.get().add(data.getPerspective());
-      
+
       // Trap browser reload and close events (they're indistinguishable), and
       // present a message to the user. Store this handler in the Perspective.
       HandlerRegistration handler;
@@ -858,7 +859,7 @@ public class DataTransfer {
         }
       });
       data.getPerspective().setWindowCloseHandler(handler);
-      
+
       // Get all labels belonging to the user, as well as all public labels.
       listLabels(data);
 
@@ -885,7 +886,7 @@ public class DataTransfer {
       RootLayoutPanel.get().add(data.getSignInScreen());
 
       // Remove window close handler; reset the Perspective.
-      data.getPerspective().getWindowCloseHandler().removeHandler();      
+      data.getPerspective().getWindowCloseHandler().removeHandler();
       data.getPerspective().reset();
 
       // Clear any user-owned labels from list. Locate first, then remove.
@@ -943,7 +944,8 @@ public class DataTransfer {
       } else if (Response.SC_UNAUTHORIZED == response.getStatusCode()) {
 
         // Display message if email address is valid, but password is not.
-        data.getSignInScreen().getErrorMessage().setHTML(Constants.PASSWORD_ERR);
+        data.getSignInScreen().getErrorMessage()
+            .setHTML(Constants.PASSWORD_ERR);
 
       } else {
         String msg =
@@ -951,7 +953,7 @@ public class DataTransfer {
                 + "Response code: " + response.getStatusCode();
         Window.alert(msg);
       }
-      
+
       data.showDefaultCursor();
     }
 
@@ -1100,7 +1102,7 @@ public class DataTransfer {
         GWT.log(rtxt);
         ModelListJSO jso = parse(rtxt);
         data.modelList = jso;
-        
+
       } else {
         String msg =
             "The URL '" + url + "' did not give an 'OK' response. "
@@ -1165,7 +1167,7 @@ public class DataTransfer {
     }
 
     /*
-     * A helper for attaching all selected labels to (and detaching all 
+     * A helper for attaching all selected labels to (and detaching all
      * unselected labels from) a model.
      */
     private void updateSelectedLabels(Integer modelId) {
@@ -1340,7 +1342,7 @@ public class DataTransfer {
       ListBox droplist =
           data.getPerspective().getOpenDialogBox().getDroplistPanel()
               .getDroplist();
-      
+
       // Populate the droplist with the restricted list of models.
       droplist.clear();
       for (int i = 0; i < jso.getIds().length(); i++) {
@@ -1350,11 +1352,12 @@ public class DataTransfer {
       }
 
       // Show metadata for the first model in the droplist.
-      String selectedModelName = droplist.getItemText(droplist.getSelectedIndex());
-      data.getPerspective().getOpenDialogBox().getMetadataPanel()
-          .setOwner(data.findModel(selectedModelName).getOwner());
-      data.getPerspective().getOpenDialogBox().getMetadataPanel()
-          .setDate(data.findModel(selectedModelName).getDate());
+      String selectedModelName =
+          droplist.getItemText(droplist.getSelectedIndex());
+      data.getPerspective().getOpenDialogBox().getMetadataPanel().setOwner(
+          data.findModel(selectedModelName).getOwner());
+      data.getPerspective().getOpenDialogBox().getMetadataPanel().setDate(
+          data.findModel(selectedModelName).getDate());
     }
 
     /*
@@ -1366,8 +1369,9 @@ public class DataTransfer {
         for (int i = 0; i < jso.getIds().length(); i++) {
 
           GWT.log("Entry : " + entry.getValue().getId());
-          GWT.log("JSO : " + jso.getIds().get(i)); // fails in dev mode, see LabelQueryJSOTest#testGetIds
-          
+          GWT.log("JSO : " + jso.getIds().get(i)); // fails in dev mode, see
+// LabelQueryJSOTest#testGetIds
+
           if (entry.getValue().getId() == jso.getIds().get(i)) {
             entry.getValue().isSelected(true);
           }

--- a/src/edu/colorado/csdms/wmt/client/control/package-info.java
+++ b/src/edu/colorado/csdms/wmt/client/control/package-info.java
@@ -1,28 +1,6 @@
 /**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-/**
- * The presenter classes used in WMT.
+ * The presenter classes used in WMT, they control the presentation logic in the
+ * application.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */

--- a/src/edu/colorado/csdms/wmt/client/data/ModelComponentJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ModelComponentJSO.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.data;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -147,7 +124,7 @@ public class ModelComponentJSO extends JavaScriptObject {
   /**
    * JSNI method to set the "connect" attribute of a ModelComponentJSO.
    * 
-   * @param parameters a {@link ModelComponentConnectionsJSO} object
+   * @param connect a {@link ModelComponentConnectionsJSO} object
    */
   public final native void setConnections(ModelComponentConnectionsJSO connect) /*-{
 		this.connect = connect;

--- a/src/edu/colorado/csdms/wmt/client/data/ModelListJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ModelListJSO.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.data;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -31,9 +8,13 @@ import com.google.gwt.core.client.JsArray;
  * HTTP GET call to <a
  * href="http://csdms.colorado.edu/wmt/models/list">models/list</a>. Declares
  * JSNI methods to access attributes.
+ * <p>
+ * For more on GWT JSO types, see <a href=
+ * "http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html"
+ * >DevGuideCodingBasicsOverlay</a> and <a
+ * href="http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html"
+ * >DevGuideCodingBasicsJSNI</a>.
  * 
- * @see <a
- *      href="http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html">http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html</a>
  * @author Mark Piper (mark.piper@colorado.edu)
  */
 public class ModelListJSO extends JavaScriptObject {

--- a/src/edu/colorado/csdms/wmt/client/data/ModelMetadataJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ModelMetadataJSO.java
@@ -1,35 +1,12 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.data;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
 /**
- * A GWT JavaScript overlay (JSO) type that gives the metadata for a WMT
- * model, including the owner, the model id, the model name, and the creation
- * date; information corresponding to the "open" URL in the API. Declares JSNI 
- * methods to access these attributes.
+ * A GWT JavaScript overlay (JSO) type that gives the metadata for a WMT model,
+ * including the owner, the model id, the model name, and the creation date;
+ * information corresponding to the "open" URL in the API. Declares JSNI methods
+ * to access these attributes.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */
@@ -56,10 +33,10 @@ public class ModelMetadataJSO extends JavaScriptObject {
   }-*/;
 
   /**
-   * A JSNI method to get the id of the model, an int used to uniquely
-   * identify it in the database. The user can't modify this id -- it's set by
-   * the API. Be aware that this is different than {@link ModelJSO#getId()},
-   * which is used to get the id of a component.
+   * A JSNI method to get the id of the model, an int used to uniquely identify
+   * it in the database. The user can't modify this id -- it's set by the API.
+   * Be aware that this is different than {@link ComponentJSO#getId()}, which is
+   * used to get the id of a component.
    * <p>
    * Returns a value of -1 if no model metadata are present.
    */

--- a/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
@@ -9,11 +9,14 @@ import com.google.gwt.core.client.JavaScriptObject;
  * component model, with "key", "name", "description" and "value" attributes.
  * Declares JSNI methods to access these attributes from a JSON and modify
  * them in memory.
+ * <p>
+ * For more on GWT JSO types, see <a href=
+ * "http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html"
+ * >DevGuideCodingBasicsOverlay</a> and <a
+ * href="http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html"
+ * >DevGuideCodingBasicsJSNI</a>.
  * 
- * @see <a
- *      href="http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html">http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html</a>
  * @author Mark Piper (mark.piper@colorado.edu)
- * 
  */
 public class ParameterJSO extends JavaScriptObject {
 

--- a/src/edu/colorado/csdms/wmt/client/data/PortJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/PortJSO.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.data;
 
 import java.util.Vector;
@@ -32,9 +9,13 @@ import com.google.gwt.core.client.JsArrayString;
  * A GWT JavaScript overlay (JSO) type that describes ports that a WMT component
  * model provides and uses, with "id" and "required" attributes. Declares JSNI
  * methods to access these attributes from a JSON and modify them in memory.
+ * <p>
+ * For more on GWT JSO types, see <a href=
+ * "http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html"
+ * >DevGuideCodingBasicsOverlay</a> and <a
+ * href="http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html"
+ * >DevGuideCodingBasicsJSNI</a>.
  * 
- * @see <a
- *      href="http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html">http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html</a>
  * @author Mark Piper (mark.piper@colorado.edu)
  */
 public class PortJSO extends JavaScriptObject {
@@ -59,7 +40,7 @@ public class PortJSO extends JavaScriptObject {
   public final native void setId(String id) /*-{
 		this.id = id;
   }-*/;
-  
+
   /**
    * JSNI method to get the "required" attribute of a port. If this attribute is
    * not present, false is returned. Note that the return is a JS boolean, not a
@@ -68,7 +49,7 @@ public class PortJSO extends JavaScriptObject {
   public final native boolean isRequired() /*-{
 		return (typeof this.required == 'undefined') ? false : this.required;
   }-*/;
-  
+
   /**
    * A JSNI method to set the "required" attribute of a port.
    * 
@@ -79,9 +60,9 @@ public class PortJSO extends JavaScriptObject {
   }-*/;
 
   /**
-   * A JSNI method to access the "exchange_items" attribute of a PortJSO. May not be
-   * present, though ignored without an exception; is an array of strings,
-   * represented by a JsArrayString object.
+   * A JSNI method to access the "exchange_items" attribute of a PortJSO. May
+   * not be present, though ignored without an exception; is an array of
+   * strings, represented by a JsArrayString object.
    */
   public final native JsArrayString getExchangeItems() /*-{
 		return this.exchange_items;

--- a/src/edu/colorado/csdms/wmt/client/data/ValueJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ValueJSO.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.data;
 
 import java.util.Vector;
@@ -29,15 +6,18 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 
 /**
- * A GWT JavaScript overlay (JSO) type that describes the values of a
- * parameter for a WMT component model, with "type", "default", "units",
- * "range" and "choices" attributes. Declares JSNI methods to access these
- * attributes from a JSON and modify them in memory.
+ * A GWT JavaScript overlay (JSO) type that describes the values of a parameter
+ * for a WMT component model, with "type", "default", "units", "range" and
+ * "choices" attributes. Declares JSNI methods to access these attributes from a
+ * JSON and modify them in memory.
+ * <p>
+ * For more on GWT JSO types, see <a href=
+ * "http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html"
+ * >DevGuideCodingBasicsOverlay</a> and <a
+ * href="http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html"
+ * >DevGuideCodingBasicsJSNI</a>.
  * 
- * @see <a
- *      href="http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html">http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsOverlay.html</a>
  * @author Mark Piper (mark.piper@colorado.edu)
- * 
  */
 public class ValueJSO extends JavaScriptObject {
 
@@ -58,7 +38,7 @@ public class ValueJSO extends JavaScriptObject {
    * present. Coerce result to string.
    */
   public final native String getDefault() /*-{
-    // "default" is reserved in JavaScript; use hash notation to access.
+		// "default" is reserved in JavaScript; use hash notation to access.
 		return this["default"].toString();
   }-*/;
 
@@ -68,10 +48,10 @@ public class ValueJSO extends JavaScriptObject {
    * @param value the value to set, of type String, Integer or Double
    */
   public final native <T> void setDefault(T value) /*-{
-    // "default" is reserved in JavaScript; use hash notation to access.
-    this["default"] = value;
+		// "default" is reserved in JavaScript; use hash notation to access.
+		this["default"] = value;
   }-*/;
-  
+
   /**
    * A JSNI method to access the "units" attribute of a ValueJSO. May not be
    * present, though ignored without an exception; is a string.
@@ -84,8 +64,6 @@ public class ValueJSO extends JavaScriptObject {
    * JSNI method to access the "range.min" attribute of a ValueJSO. May not be
    * present. The undefined check on "range" attribute is necessary. I'm
    * choosing to cast value to string, because long integers aren't supported.
-   * 
-   * @see http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html
    */
   public final native String getMin() /*-{
 		if (typeof this.range == 'undefined') {
@@ -99,8 +77,6 @@ public class ValueJSO extends JavaScriptObject {
    * JSNI method to access the "range.max" attribute of a ValueJSO. May not be
    * present. The undefined check on "range" attribute is necessary. I'm
    * choosing to cast value to string, because long integers aren't supported.
-   * 
-   * @see http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html
    */
   public final native String getMax() /*-{
 		if (typeof this.range == 'undefined') {

--- a/src/edu/colorado/csdms/wmt/client/data/package-info.java
+++ b/src/edu/colorado/csdms/wmt/client/data/package-info.java
@@ -1,28 +1,6 @@
 /**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-/**
- * The data-handling classes used in WMT.
+ * The data-handling classes used in WMT, derived from the GWT
+ * {@link com.google.gwt.core.client.JavaScriptObject}.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */

--- a/src/edu/colorado/csdms/wmt/client/package-info.java
+++ b/src/edu/colorado/csdms/wmt/client/package-info.java
@@ -1,28 +1,7 @@
 /**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-/**
- * The base class for the CSDMS Modeling Tool (WMT).
+ * The top-level package for the CSDMS Web Modeling Tool (WMT) client. It holds
+ * the {@link edu.colorado.csdms.wmt.client.WMT} base class, styles, and
+ * resources.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */

--- a/src/edu/colorado/csdms/wmt/client/security/Security.java
+++ b/src/edu/colorado/csdms/wmt/client/security/Security.java
@@ -70,7 +70,7 @@ public class Security {
    * Stores the hostname of the machine where the user wants the model to be
    * run.
    * 
-   * @param hpccHostname
+   * @param hostname the hostname
    */
   public void setHpccHostname(String hostname) {
     this.hpccHostname = hostname;
@@ -86,7 +86,7 @@ public class Security {
   /**
    * Stores the user's username for the host on which the model is to be run.
    * 
-   * @param hpccUsername
+   * @param username the username
    */
   public void setHpccUsername(String username) {
     this.hpccUsername = username;
@@ -102,7 +102,7 @@ public class Security {
   /**
    * Stores the user's password for the host on which the model is to be run.
    * 
-   * @param hpccPassword
+   * @param password the user's password
    */
   public void setHpccPassword(String password) {
     this.hpccPassword = password;
@@ -118,7 +118,7 @@ public class Security {
   /**
    * Stores the user's login name for the WMT client.
    * 
-   * @param wmtUsername
+   * @param wmtUsername the user's login name
    */
   public void setWmtUsername(String wmtUsername) {
     this.wmtUsername = wmtUsername;
@@ -134,7 +134,7 @@ public class Security {
   /**
    * Stores the user's password for the WMT client.
    * 
-   * @param wmtPassword
+   * @param wmtPassword the password
    */
   public void setWmtPassword(String wmtPassword) {
     this.wmtPassword = wmtPassword;
@@ -150,7 +150,7 @@ public class Security {
   /**
    * Sets whether the user is currently logged into WMT.
    * 
-   * @param isLoggedIn
+   * @param isLoggedIn true if user is logged in
    */
   public void isLoggedIn(Boolean isLoggedIn) {
     this.isLoggedIn = isLoggedIn;

--- a/src/edu/colorado/csdms/wmt/client/security/package-info.java
+++ b/src/edu/colorado/csdms/wmt/client/security/package-info.java
@@ -1,27 +1,6 @@
 /**
- * The MIT License (MIT)
+ * Login and authentication classes.
  * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-/**
  * @author Mark Piper (mark.piper@colorado.edu)
  * 
  */

--- a/src/edu/colorado/csdms/wmt/client/ui/ModelTree.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ModelTree.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui;
 
 import java.util.ArrayList;
@@ -40,7 +17,7 @@ import edu.colorado.csdms.wmt.client.ui.handler.ComponentSelectionCommand;
 
 /**
  * A ModelTree is used to graphically represent the construction of a simulation
- * through component models, each represented by a {@link ModelCell}.
+ * through component models, each represented by a {@link ComponentCell}.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */

--- a/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
@@ -32,7 +32,7 @@ public class ParameterTable extends FlexTable {
 
   /**
    * Initializes a table of parameters for a single WMT model component. The
-   * table is empty until {@link #loadTable()} is called.
+   * table is empty until {@link #loadTable(String)} is called.
    * 
    * @param data the DataManager instance for the WMT session
    */
@@ -45,10 +45,10 @@ public class ParameterTable extends FlexTable {
 
   /**
    * A worker that loads the ParameterTable with parameter values for the
-   * selected model component. Displays a {@link ViewInputFilesPanel} at the
-   * bottom of the table.
+   * selected model component.
    * 
-   * @param the id of the component whose parameters are to be displayed
+   * @param componentId the id of the component whose parameters are to be
+   *  displayed
    */
   public void loadTable(String componentId) {
 

--- a/src/edu/colorado/csdms/wmt/client/ui/dialog/ComponentInfoDialogBox.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/dialog/ComponentInfoDialogBox.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.dialog;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -50,7 +27,7 @@ public class ComponentInfoDialogBox extends DialogBox {
 
   /**
    * Creates an {@link ComponentInfoDialogBox}. It must be populated later by
-   * calling {@link ComponentInfoDialogBox#update()}.
+   * calling {@link #update(ComponentJSO)}.
    */
   public ComponentInfoDialogBox() {
 

--- a/src/edu/colorado/csdms/wmt/client/ui/dialog/NewUserDialogBox.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/dialog/NewUserDialogBox.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.dialog;
 
 import com.google.gwt.dom.client.Style.Unit;
@@ -46,8 +23,6 @@ public class NewUserDialogBox extends DialogBox {
   
   /**
    * Creates a {@link NewUserDialogBox}.
-   * 
-   * @param data the DataManager object for the WMT session
    */
   public NewUserDialogBox() {
 

--- a/src/edu/colorado/csdms/wmt/client/ui/dialog/UploadDialogBox.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/dialog/UploadDialogBox.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.dialog;
 
 import com.google.gwt.dom.client.Style.Unit;
@@ -43,17 +20,18 @@ import edu.colorado.csdms.wmt.client.ui.handler.DialogCancelHandler;
 import edu.colorado.csdms.wmt.client.ui.panel.ChoicePanel;
 
 /**
- * A dialog box with a {@link FormPanel} that holds a {@link FileUpload}
- * widget and a {@link ChoicePanel}. Use it to choose a file for upload to the
- * WMT server.
+ * A dialog box with a {@link FormPanel} that holds a {@link FileUpload} widget
+ * and a {@link ChoicePanel}. Use it to choose a file for upload to the WMT
+ * server.
+ * <p>
+ * See <a href="http://davidwalsh.name/fakepath">This</a> blog post on
+ * <code>C:\fakepath</code> and file uploads. Doesn't matter, though; the
+ * browser takes care of this.
  * 
- * @see <a href="http://davidwalsh.name/fakepath">This</a> blog post on
- *      <code>C:\fakepath</code> and file uploads. Doesn't matter, though; the
- *      browser takes care of this.
  * @author Mark Piper (mark.piper@colorado.edu)
  */
 public class UploadDialogBox extends DialogBox {
-  
+
   private FormPanel form;
   private Hidden hidden;
   private FileUpload upload;
@@ -61,8 +39,8 @@ public class UploadDialogBox extends DialogBox {
   /**
    * Creates an {@link UploadDialogBox}.
    * <p>
-   * Note that the form action and value of the hidden field need to be set
-   * when this dialog is employed. (Enforcing MVP separation of M and V.)
+   * Note that the form action and value of the hidden field need to be set when
+   * this dialog is employed. (Enforcing MVP separation of M and V.)
    */
   public UploadDialogBox() {
 
@@ -125,8 +103,8 @@ public class UploadDialogBox extends DialogBox {
     });
 
     /*
-     * This handler is called just before the form is submitted. Can be used
-     * to perform validation.
+     * This handler is called just before the form is submitted. Can be used to
+     * perform validation.
      */
     form.addSubmitHandler(new SubmitHandler() {
       @Override
@@ -154,7 +132,7 @@ public class UploadDialogBox extends DialogBox {
   public void setHidden(Hidden hidden) {
     this.hidden = hidden;
   }
-  
+
   public FileUpload getUpload() {
     return upload;
   }
@@ -162,5 +140,5 @@ public class UploadDialogBox extends DialogBox {
   public void setUpload(FileUpload upload) {
     this.upload = upload;
   }
-  
+
 }

--- a/src/edu/colorado/csdms/wmt/client/ui/dialog/package-info.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/dialog/package-info.java
@@ -1,7 +1,7 @@
 /**
- * Dialogs (or {@link com.google.gwt.user.client.ui.DialogBox}es) are modal
- * panels that float above the WMT interface. They need to be clicked to be
- * dismissed.
+ * Dialogs, derived from {@link com.google.gwt.user.client.ui.DialogBox}, are
+ * modal panels that float above the WMT interface. They need to be clicked to
+ * be dismissed.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelSaveHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelSaveHandler.java
@@ -16,7 +16,7 @@ import edu.colorado.csdms.wmt.client.ui.dialog.SaveDialogBox;
 /**
  * Handles click on the "Save" or "Save As..." buttons in the ModelActionPanel.
  * Saves a not-previously-saved model or a new model displayed in WMT to the
- * server with a call to {@link DataTransfer#postModel(DataManager)}.
+ * server with a call to {@link DataTransfer#postModel(DataManager, String)}.
  */
 public class ModelActionPanelSaveHandler implements ClickHandler {
 

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ParameterActionPanelResetHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ParameterActionPanelResetHandler.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.handler;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -32,9 +9,9 @@ import edu.colorado.csdms.wmt.client.ui.dialog.QuestionDialogBox;
 
 /**
  * Handles a click on the "Reset" button in the ParameterActionPanel. Calls
- * {@link DataManager#replaceModelComponent()} to replace the current model 
- * component with the default component, then displays its parameters in
- * the ParameterTable.
+ * {@link DataManager#replaceModelComponent(edu.colorado.csdms.wmt.client.data.ComponentJSO)}
+ * to replace the current model component with the default component, then
+ * displays its parameters in the ParameterTable.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */
@@ -42,7 +19,7 @@ public class ParameterActionPanelResetHandler implements ClickHandler {
 
   private DataManager data;
   private String componentId;
-  
+
   /**
    * Creates a new instance of {@link ParameterActionPanelResetHandler}.
    * 
@@ -53,7 +30,7 @@ public class ParameterActionPanelResetHandler implements ClickHandler {
     this.data = data;
     this.componentId = componentId;
   }
-  
+
   @Override
   public void onClick(ClickEvent event) {
     final QuestionDialogBox questionDialog =

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/SaveModelHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/SaveModelHandler.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.handler;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -36,7 +13,7 @@ import edu.colorado.csdms.wmt.client.ui.dialog.SaveDialogBox;
  * Handles click on the "OK" button in the save dialog that appears when the
  * "Save Model As..." button is clicked in the ModelActionPanel. Uses
  * {@link DataManager#serialize()} to serialize the model, then posts it to the
- * server with {@link DataTransfer#postModel(DataManager)}.
+ * server with {@link DataTransfer#postModel(DataManager, String)}.
  */
 public class SaveModelHandler implements ClickHandler {
 

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/package-info.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/package-info.java
@@ -1,28 +1,5 @@
 /**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-/**
- * This package contains event handlers for the WMT client.
+ * Event handling classes for the WMT client.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */

--- a/src/edu/colorado/csdms/wmt/client/ui/package-info.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/package-info.java
@@ -1,28 +1,5 @@
 /**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-/**
- * Classes used to build the WMT graphical user interface.
+ * Classes used to build the WMT client graphical user interface.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */

--- a/src/overview.html
+++ b/src/overview.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+   <head>
+      <title>WMT Client Documentation</title>
+   </head>
+   <body>
+      <h1>WMT Client Documentation</h1>
+      
+      <p>Source code documentation for the Community Surface Dynamics Modeling 
+      System (CSDMS) Web Modeling Tool (WMT) client.
+
+      <p>For more information on CSDMS and WMT,
+      please visit the CSDMS home page at
+      <a href="http://csdms.colorado.edu">http://csdms.colorado.edu</a>.
+   </body>
+</html>


### PR DESCRIPTION
In this PR, I added a `javadoc` target to the buildfile, so now we can produce documentation for **wmt-client**. Most of the other changes were just cleaning up errors and warnings encountered in the build process.