### PR TITLE
New selection parameter datatype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /war/edu.colorado.csdms.wmt.WMT.JUnit
 /war/WEB-INF/classes
 /war/WEB-INF/deploy
+/war/build_id
 
 *.jar
 

--- a/build.xml
+++ b/build.xml
@@ -148,7 +148,15 @@
 		<delete dir="${war.dir}/save" failonerror="false" />
 	</target>
 
-	<target name="build" depends="gwtc" description="Build this project" />
+	<target name="build_id" description="Save the latest commit id of this build">
+		<exec executable="git" output="${war.dir}/build_id">
+			<arg value="rev-parse"/>
+			<arg value="--short"/>
+			<arg value="HEAD"/>
+		</exec>
+	</target>
+
+	<target name="build" depends="gwtc, build_id" description="Build this project"/>
 
 	<target name="war" depends="build" description="Create a war file">
 		<zip destfile="${war.file}" basedir="${war.dir}"

--- a/src/edu/colorado/csdms/wmt/client/data/ComponentJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ComponentJSO.java
@@ -138,11 +138,6 @@ public class ComponentJSO extends JavaScriptObject {
   public final native JsArray<PortJSO> getProvidesPorts() /*-{
 		return this.provides;
   }-*/;
-  
-  @Deprecated
-  public final native JsArray<PortJSO> getPortsProvided() /*-{
-		return this.provides;
-  }-*/;
 
   /**
    * A convenience method that returns the number of CCA uses ports a
@@ -162,11 +157,6 @@ public class ComponentJSO extends JavaScriptObject {
    * it may be empty.
    */
   public final native JsArray<PortJSO> getUsesPorts() /*-{
-		return this.uses;
-  }-*/;
-
-  @Deprecated
-  public final native JsArray<PortJSO> getPortsUsed() /*-{
 		return this.uses;
   }-*/;
 
@@ -203,12 +193,12 @@ public class ComponentJSO extends JavaScriptObject {
     retVal.add("id: " + getId());
     retVal.add("name: " + getName());
     retVal.add("url: " + getURL());
-    for (int i = 0; i < getPortsProvided().length(); i++) {
+    for (int i = 0; i < getProvidesPorts().length(); i++) {
       retVal.add("provides: "
-          + getPortsProvided().get(i).toStringVector().toString());
+          + getProvidesPorts().get(i).toStringVector().toString());
     }
-    for (int i = 0; i < getPortsUsed().length(); i++) {
-      retVal.add("uses: " + getPortsUsed().get(i).toStringVector().toString());
+    for (int i = 0; i < getUsesPorts().length(); i++) {
+      retVal.add("uses: " + getUsesPorts().get(i).toStringVector().toString());
     }
     return retVal;
   }

--- a/src/edu/colorado/csdms/wmt/client/data/ComponentJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ComponentJSO.java
@@ -161,6 +161,19 @@ public class ComponentJSO extends JavaScriptObject {
   }-*/;
 
   /**
+   * Counts the parameters of a component.
+   * 
+   * @return the number of parameters as an int
+   */
+  public final native int nParameters() /*-{
+    var n = 0;
+		if (typeof this.parameters != 'undefined') {
+			n = Object.keys(this.parameters).length;
+		}
+    return n;
+  }-*/;
+
+  /**
    * A JSNI method that returns the JsArray of component parameters.
    */
   public final native JsArray<ParameterJSO> getParameters() /*-{

--- a/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
@@ -94,10 +94,51 @@ public class ParameterJSO extends JavaScriptObject {
 
   /**
    * A JSNI method to get the number of members in a group, a JS int. If the
-   * group or the members atribute doesn't exist, 0 is returned.
+   * group or the members attribute doesn't exist, 0 is returned.
    */
   public final native int nGroupMembers() /*-{
 		return this.group && this.group.members || 0;
+  }-*/;
+
+  /**
+   * A JSNI method for checking whether a ParameterJSO has a "selection"
+   * attribute. A JS boolean is returned.
+   */
+  public final native boolean hasSelection() /*-{
+		return 'selection' in this;
+  }-*/;
+
+  /**
+   * A JSNI method to get the "name" attribute of a selection, a String. If the
+   * selection or the name doesn't exist, null is returned.
+   */
+  public final native String getSelectionName() /*-{
+		return this.selection && this.selection.name || null;
+  }-*/;
+
+  /**
+   * A JSNI method to get the "selector" attribute of a group, a JS boolean. If
+   * the selection or the leader doesn't exist, false is returned.
+   */
+  public final native boolean isSelector() /*-{
+		return this.selection && this.selection.selector || false;
+  }-*/;
+
+  /**
+   * A JSNI method to get the number of members in a selection, a JS int. If the
+   * selection or the members attribute doesn't exist, 0 is returned.
+   */
+  public final native int nSelectionMembers() /*-{
+		return this.selection && this.selection.selections || 0;
+  }-*/;
+
+  /**
+   * A JSNI method to get the mapping of a choice in the selector to the
+   * appropriate member in the selection. Both the input choice and the output
+   * mapping are Strings.
+   */
+  public final native String getSelectionMapping(String choice) /*-{
+		return this.selection.mapping[choice];
   }-*/;
 
   /**

--- a/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
@@ -129,7 +129,7 @@ public class ParameterJSO extends JavaScriptObject {
    * selection or the members attribute doesn't exist, 0 is returned.
    */
   public final native int nSelectionMembers() /*-{
-		return this.selection && this.selection.selections || 0;
+		return this.selection && this.selection.members || 0;
   }-*/;
 
   /**

--- a/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
@@ -121,7 +121,7 @@ public class ParameterTable extends FlexTable {
 
     if (parameter.isGroupLeader()) {
       ArrayList<Integer> groupRows = new ArrayList<Integer>();
-      for (int i = 0; i < parameter.nGroupMembers(); i++) {
+      for (int i = 0; i < (parameter.nGroupMembers() - 1); i++) {
         groupRows.add(tableRowIndex + i + 1);
       }
       descriptionCell.setGroupRows(groupRows);

--- a/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
@@ -9,7 +9,6 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
-
 import edu.colorado.csdms.wmt.client.control.DataManager;
 import edu.colorado.csdms.wmt.client.data.ParameterJSO;
 import edu.colorado.csdms.wmt.client.ui.cell.DescriptionCell;
@@ -109,9 +108,11 @@ public class ParameterTable extends FlexTable {
       return;
     }
 
-    final DescriptionCell descriptionCell = new DescriptionCell(parameter);
+    // Set up the description and value of the parameter.
+    DescriptionCell descriptionCell = new DescriptionCell(parameter);
+    ValueCell valueCell = new ValueCell(parameter);
     this.setWidget(tableRowIndex, 0, descriptionCell);
-    this.setWidget(tableRowIndex, 1, new ValueCell(parameter));
+    this.setWidget(tableRowIndex, 1, valueCell);
     this.getFlexCellFormatter().setHorizontalAlignment(tableRowIndex, 1,
         HasHorizontalAlignment.ALIGN_RIGHT);
 
@@ -125,21 +126,7 @@ public class ParameterTable extends FlexTable {
         groupRows.add(tableRowIndex + i + 1);
       }
       descriptionCell.setGroupRows(groupRows);
-
-      descriptionCell.addDomHandler(new ClickHandler() {
-        @Override
-        public void onClick(ClickEvent event) {
-          RowFormatter rowFormatter = ParameterTable.this.getRowFormatter();
-          ArrayList<Integer> theRows = descriptionCell.getGroupRows();
-          for (Integer row : theRows) {
-            rowFormatter.setVisible(row, !rowFormatter.isVisible(row));
-          }
-          descriptionCell.areGroupRowsVisible(!descriptionCell
-              .areGroupRowsVisible());
-          descriptionCell.setStyleDependentName("groupLeader-open",
-              descriptionCell.areGroupRowsVisible());
-        }
-      }, ClickEvent.getType());
+      descriptionCell.addClickHandler(new GroupVisibilityHandler());
     }
 
     tableRowIndex++;
@@ -197,5 +184,26 @@ public class ParameterTable extends FlexTable {
    */
   public void setComponentId(String componentId) {
     this.componentId = componentId;
+  }
+
+  /**
+   * Handles a click on the DescriptionCell of a parameter group. Toggles the
+   * visibility of the parameters in the group.
+   */
+  public class GroupVisibilityHandler implements ClickHandler {
+
+    @Override
+    public void onClick(ClickEvent event) {
+      DescriptionCell descriptionCell = (DescriptionCell) event.getSource();
+      RowFormatter rowFormatter = ParameterTable.this.getRowFormatter();
+      ArrayList<Integer> theRows = descriptionCell.getGroupRows();
+      for (Integer row : theRows) {
+        rowFormatter.setVisible(row, !rowFormatter.isVisible(row));
+      }
+      descriptionCell.areGroupRowsVisible(!descriptionCell.areGroupRowsVisible());
+      descriptionCell.setStyleDependentName("groupLeader-open",
+              descriptionCell.areGroupRowsVisible());
+    }
+
   }
 }

--- a/src/edu/colorado/csdms/wmt/client/ui/cell/ValueCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/ValueCell.java
@@ -16,6 +16,7 @@ import edu.colorado.csdms.wmt.client.ui.ParameterTable;
 public class ValueCell extends HorizontalPanel {
 
   private ParameterJSO parameter;
+  private String cellType;
 
   /**
    * Makes a ValueCell from the information contained in the input
@@ -26,17 +27,17 @@ public class ValueCell extends HorizontalPanel {
   public ValueCell(ParameterJSO parameter) {
 
     this.parameter = parameter;
+    this.cellType = this.parameter.getValue().getType();
     this.setStyleName("wmt-ValueCell");
 
     // Add a cell to match the parameter type.
-    String type = this.parameter.getValue().getType();
-    if (type.matches("choice")) {
+    if (isChoice()) {
       this.add(new ChoiceCell(this));
-    } else if (type.matches("file")) {
+    } else if (isFile()) {
       this.add(new FileCell(this));
-    } else if (type.matches("int")) {
+    } else if (isInt()) {
       this.add(new IntegerCell(this));
-    } else if (type.matches("float")) {
+    } else if (isFloat()) {
       this.add(new DoubleCell(this));
     } else {
       this.add(new TextCell(this));
@@ -62,5 +63,41 @@ public class ValueCell extends HorizontalPanel {
   public void setParameterValue(String value) {
     ParameterTable pt = (ParameterTable) ValueCell.this.getParent();
     pt.setValue(parameter, value);
+  }
+
+  /**
+   * States whether parameter is of type "choice".
+   * 
+   * @return true if the parameter type is "choice"
+   */
+  public Boolean isChoice() {
+    return cellType.matches("choice");
+  }
+
+  /**
+   * States whether parameter is of type "file".
+   * 
+   * @return true if the parameter type is "file"
+   */
+  public Boolean isFile() {
+    return cellType.matches("file");
+  }
+
+  /**
+   * States whether parameter is of type "int".
+   * 
+   * @return true if the parameter type is "int"
+   */
+  public Boolean isInt() {
+    return cellType.matches("int");
+  }
+
+  /**
+   * States whether parameter is of type "float".
+   * 
+   * @return true if the parameter type is "float"
+   */
+  public Boolean isFloat() {
+    return cellType.matches("float");
   }
 }

--- a/test/edu/colorado/csdms/wmt/client/ComponentJSOTest.java
+++ b/test/edu/colorado/csdms/wmt/client/ComponentJSOTest.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client;
 
 import org.junit.After;
@@ -45,7 +22,8 @@ public class ComponentJSOTest extends GWTTestCase {
   private ComponentJSO componentJSO;
   private String id;
   private String componentClass;
-  private String name;  
+  private String name;
+  private Integer nParameters;
   
   /**
    * The module that sources this class. Must be present.
@@ -68,7 +46,15 @@ public class ComponentJSOTest extends GWTTestCase {
 		return {
 			"id" : id,
 			"class" : componentClass,
-			"name" : name
+			"name" : name,
+			"parameters" : [
+			  {
+			    "key":"separator"
+			  },
+			  {
+			    "key":"run_duration"
+			  }
+			]
 		}
   }-*/;  
   
@@ -78,6 +64,7 @@ public class ComponentJSOTest extends GWTTestCase {
     id = "child";
     componentClass = "Child";
     name = "Child_0";
+    nParameters = 2;
     componentJSO = testComponentJSO(id, componentClass, name);
   }
 
@@ -99,5 +86,11 @@ public class ComponentJSOTest extends GWTTestCase {
   @Test
   public void testGetName() {
     assertEquals(name, componentJSO.getName());
+  }
+
+  @Test
+  public void testNParameters() {
+    Integer actual = componentJSO.nParameters();
+    assertEquals(nParameters, actual);
   }
 }

--- a/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
+++ b/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
@@ -13,13 +13,18 @@ import edu.colorado.csdms.wmt.client.data.ValueJSO;
  * Tests for {@link ParameterJSO}. JUnit integration is provided by extending
  * {@link GWTTestCase}.
  * 
- * @see http://www.gwtproject.org/doc/latest/DevGuideTesting.html
- * @see http://www.gwtproject.org/doc/latest/tutorial/JUnit.html
+ * For more information, see
+ * <a href="http://www.gwtproject.org/doc/latest/DevGuideTesting.html">
+ * DevGuideTesting</a> and
+ * <a href="http://www.gwtproject.org/doc/latest/tutorial/JUnit.html">
+ * JUnit</a>.
+ * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */
 public class ParameterJSOTest extends GWTTestCase {
 
-  private ParameterJSO jso;
+  private ParameterJSO basicParam;
+  private ParameterJSO groupParam;
   private String key;
   private String name;
   private String description;
@@ -29,21 +34,34 @@ public class ParameterJSOTest extends GWTTestCase {
   private Integer groupMembers;
   private ValueJSO value;
 
-  /**
-   * The module that sources this class. Must be present.
-   */
+  // The module that sources this class. Must be present.
   @Override
   public String getModuleName() {
      return "edu.colorado.csdms.wmt.WMT";
   }
 
   /**
-   * A JSNI method that defines a fixture for the tests. Returns a
-   * {@link ParameterJSO} object for testing.
+   * A JSNI method that defines a fixture for testing. Returns a basic
+   * {@link ParameterJSO} object.
    */
-  private native ParameterJSO testParameterJSO(String key, String name,
+  private native ParameterJSO testBasicParameterJSO(String key, String name,
+      String description, Boolean visible, ValueJSO value) /*-{
+		return {
+			"key" : key,
+			"name" : name,
+			"description" : description,
+			"visible" : visible,
+			"value" : value
+		};
+  }-*/;
+
+  /**
+   * A JSNI method that defines a fixture for testing. Returns a
+   * {@link ParameterJSO} object with a group.
+   */
+  private native ParameterJSO testGroupParameterJSO(String key, String name,
       String description, String groupName, Boolean groupLeader,
-      Integer groupMembers, Boolean visible, ValueJSO value) /*-{
+      Integer groupMembers, ValueJSO value) /*-{
 		return {
 			"key" : key,
 			"name" : name,
@@ -53,7 +71,6 @@ public class ParameterJSOTest extends GWTTestCase {
 				"leader" : groupLeader,
 				"members" : groupMembers
 			},
-			"visible" : visible,
 			"value" : value
 		};
   }-*/;
@@ -84,9 +101,10 @@ public class ParameterJSOTest extends GWTTestCase {
     groupMembers = 3;
     visible = true;
     value = testValueJSO();
-    jso =
-        testParameterJSO(key, name, description, groupName, groupLeader,
-            groupMembers, visible, value);
+    basicParam = testBasicParameterJSO(key, name, description, visible, value);
+    groupParam =
+        testGroupParameterJSO(key, name, description, groupName, groupLeader,
+            groupMembers, value);
   }
 
   @After
@@ -96,52 +114,52 @@ public class ParameterJSOTest extends GWTTestCase {
 
   @Test
   public void testGetKey() {
-    assertEquals(key, jso.getKey());
+    assertEquals(key, basicParam.getKey());
   }
 
   @Test
   public void testGetName() {
-    assertEquals(name, jso.getName());
+    assertEquals(name, basicParam.getName());
   }
 
   @Test
   public void testGetDescription() {
-    assertEquals(description, jso.getDescription());
+    assertEquals(description, basicParam.getDescription());
   }
 
   @Test
   public void testHasGroup() {
-    assertTrue(jso.hasGroup());
+    assertTrue(groupParam.hasGroup());
   }
 
   @Test
   public void testGetGroupName() {
-    assertEquals(groupName, jso.getGroupName());
+    assertEquals(groupName, groupParam.getGroupName());
   }
 
   @Test
   public void testIsGroupLeader() {
-    assertEquals(groupLeader, (Boolean) jso.isGroupLeader());
+    assertEquals(groupLeader, (Boolean) groupParam.isGroupLeader());
   }
 
   @Test
   public void testNGroupMembers() {
-    assertEquals(groupMembers, (Integer) jso.nGroupMembers());
+    assertEquals(groupMembers, (Integer) groupParam.nGroupMembers());
   }
 
   @Test
   public void testGetIsVisible() {
-    assertTrue(jso.isVisible());
+    assertTrue(basicParam.isVisible());
   }
 
   @Test
   public void testSetIsVisible() {
-    jso.isVisible(false);
-    assertFalse(jso.isVisible());
+    basicParam.isVisible(false);
+    assertFalse(basicParam.isVisible());
   }
 
   @Test
   public void testGetValue() {
-    assertSame(value, jso.getValue());
+    assertSame(value, basicParam.getValue());
   }
 }

--- a/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
+++ b/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
@@ -25,6 +25,7 @@ public class ParameterJSOTest extends GWTTestCase {
 
   private ParameterJSO basicParam;
   private ParameterJSO groupParam;
+  private ParameterJSO selectionParam;
   private String key;
   private String name;
   private String description;
@@ -32,6 +33,9 @@ public class ParameterJSOTest extends GWTTestCase {
   private String groupName;
   private Boolean groupLeader;
   private Integer groupMembers;
+  private String selectionName;
+  private Boolean selectionSelector;
+  private Integer selectionMembers;
   private ValueJSO value;
 
   // The module that sources this class. Must be present.
@@ -76,6 +80,26 @@ public class ParameterJSOTest extends GWTTestCase {
   }-*/;
 
   /**
+   * A JSNI method that defines a fixture for testing. Returns a
+   * {@link ParameterJSO} object with a group.
+   */
+  private native ParameterJSO testSelectionParameterJSO(String key, String name,
+      String description, String selectionName, Boolean selectionSelector,
+      Integer selectionMembers, ValueJSO value) /*-{
+		return {
+			"key" : key,
+			"name" : name,
+			"description" : description,
+			"selection" : {
+				"name" : selectionName,
+				"selector" : selectionSelector,
+				"members" : selectionMembers
+			},
+			"value" : value
+		};
+  }-*/;
+
+  /**
    * A JSNI method that defines a fixture for the tests. Returns a
    * {@link ValueJSO} object for testing.
    */
@@ -96,15 +120,21 @@ public class ParameterJSOTest extends GWTTestCase {
     key = "number_of_rows";
     name = "Number of rows";
     description = "Number of rows in the computational grid";
-    groupName = "parameter1";
+    groupName = "group_parameter";
     groupLeader = true;
     groupMembers = 3;
+    selectionName = "selection_parameter";
+    selectionSelector = true;
+    selectionMembers = 9467;
     visible = true;
     value = testValueJSO();
     basicParam = testBasicParameterJSO(key, name, description, visible, value);
     groupParam =
         testGroupParameterJSO(key, name, description, groupName, groupLeader,
             groupMembers, value);
+    selectionParam =
+        testSelectionParameterJSO(key, name, description, selectionName,
+            selectionSelector, selectionMembers, value);
   }
 
   @After
@@ -145,6 +175,26 @@ public class ParameterJSOTest extends GWTTestCase {
   @Test
   public void testNGroupMembers() {
     assertEquals(groupMembers, (Integer) groupParam.nGroupMembers());
+  }
+
+  @Test
+  public void testHasSelection() {
+    assertTrue(selectionParam.hasSelection());
+  }
+
+  @Test
+  public void testGetSelectionName() {
+    assertEquals(selectionName, selectionParam.getSelectionName());
+  }
+
+  @Test
+  public void testIsSelector() {
+    assertEquals(selectionSelector, (Boolean) selectionParam.isSelector());
+  }
+
+  @Test
+  public void testNSelectionMembers() {
+    assertEquals(selectionMembers, (Integer) selectionParam.nSelectionMembers());
   }
 
   @Test

--- a/war/data/channels_diff_wave.json
+++ b/war/data/channels_diff_wave.json
@@ -206,10 +206,16 @@
       "description":"Roughness option"
     },
     {
-      "group":{
+      "selection":{
         "name":"roughness_group",
         "members":3,
-        "leader":true
+        "selector":true,
+        "mapping":{
+          "Scalar":"roughness",
+          "Time_Series":"roughness_file",
+          "Grid":"roughness_file",
+          "Grid_Sequence":"roughness_file"
+        }
       },
       "name":"Roughness value (Manning's <em>n</em> or roughness length <em>z<sub>0</sub></em>)",
       "value":{
@@ -228,10 +234,10 @@
       "description":"Roughness value (Manning's <em>n</em> or roughness length <em>z<sub>0</sub></em>)"
     },
     {
-      "group":{
+      "selection":{
         "name":"roughness_group",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Scalar value",
       "value":{
@@ -247,10 +253,10 @@
       "description":"Scalar value"
     },
     {
-      "group":{
+      "selection":{
         "name":"roughness_group",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Grid, time series, or grid sequence file",
       "value":{
@@ -265,10 +271,16 @@
       "description":"Grid, time series, or grid sequence file"
     },
     {
-      "group":{
+      "selection":{
         "name":"width_group",
         "members":3,
-        "leader":true
+        "selector":true,
+        "mapping":{
+          "Scalar":"width",
+          "Time_Series":"width_file",
+          "Grid":"width_file",
+          "Grid_Sequence":"width_file"
+        }
       },
       "name":"Bed width of trapezoid cross-section",
       "value":{
@@ -287,10 +299,10 @@
       "description":"Bed width of trapezoid cross-section"
     },
     {
-      "group":{
+      "selection":{
         "name":"width_group",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Scalar value",
       "value":{
@@ -306,10 +318,10 @@
       "description":"Scalar value"
     },
     {
-      "group":{
+      "selection":{
         "name":"width_group",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Grid, time series, or grid sequence file",
       "value":{
@@ -324,10 +336,16 @@
       "description":"Grid, time series, or grid sequence file"
     },
     {
-      "group":{
+      "selection":{
         "name":"angle_group",
         "members":3,
-        "leader":true
+        "selector":true,
+        "mapping":{
+          "Scalar":"angle",
+          "Time_Series":"angle_file",
+          "Grid":"angle_file",
+          "Grid_Sequence":"angle_file"
+        }
       },
       "name":"Bank angle of trapezoid cross-section",
       "value":{
@@ -346,10 +364,10 @@
       "description":"Bank angle of trapezoid cross-section"
     },
     {
-      "group":{
+      "selection":{
         "name":"angle_group",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Scalar value",
       "value":{
@@ -365,10 +383,10 @@
       "description":"Scalar value"
     },
     {
-      "group":{
+      "selection":{
         "name":"angle_group",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Grid, time series, or grid sequence file",
       "value":{
@@ -384,7 +402,7 @@
     },
     {
       "selection":{
-        "name":"d0_selection",
+        "name":"d0_group",
         "members":3,
         "selector":true,
         "mapping":{
@@ -412,7 +430,7 @@
     },
     {
       "selection":{
-        "name":"d0_selection",
+        "name":"d0_group",
         "members":3,
         "selector":false
       },
@@ -431,7 +449,7 @@
     },
     {
       "selection":{
-        "name":"d0_selection",
+        "name":"d0_group",
         "members":3,
         "selector":false
       },
@@ -448,10 +466,16 @@
       "description":"Grid, time series, or grid sequence file"
     },
     {
-      "group":{
+      "selection":{
         "name":"sinu_group",
         "members":3,
-        "leader":true
+        "selector":true,
+        "mapping":{
+          "Scalar":"sinu",
+          "Time_Series":"sinu_file",
+          "Grid":"sinu_file",
+          "Grid_Sequence":"sinu_file"
+        }
       },
       "name":"Absolute channel sinuosity",
       "value":{
@@ -470,10 +494,10 @@
       "description":"Absolute channel sinuosity"
     },
     {
-      "group":{
+      "selection":{
         "name":"sinu_group",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Scalar value",
       "value":{
@@ -489,10 +513,10 @@
       "description":"Scalar value"
     },
     {
-      "group":{
+      "selection":{
         "name":"sinu_group",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Grid, time series, or grid sequence file",
       "value":{

--- a/war/data/channels_diff_wave.json
+++ b/war/data/channels_diff_wave.json
@@ -383,10 +383,16 @@
       "description":"Grid, time series, or grid sequence file"
     },
     {
-      "group":{
-        "name":"d0_group",
+      "selection":{
+        "name":"d0_selection",
         "members":3,
-        "leader":true
+        "selector":true,
+        "mapping":{
+          "Scalar":"d0",
+          "Time_Series":"d0_file",
+          "Grid":"d0_file",
+          "Grid_Sequence":"d0_file"
+        }
       },
       "name":"Initial flow depth",
       "value":{
@@ -405,16 +411,16 @@
       "description":"Initial flow depth"
     },
     {
-      "group":{
-        "name":"d0_group",
+      "selection":{
+        "name":"d0_selection",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Scalar value",
       "value":{
         "default":0.0,
         "range":{
-          "max":0.0,
+          "max":10.0,
           "min":0.0
         },
         "type":"float"
@@ -424,10 +430,10 @@
       "description":"Scalar value"
     },
     {
-      "group":{
-        "name":"d0_group",
+      "selection":{
+        "name":"d0_selection",
         "members":3,
-        "leader":false
+        "selector":false
       },
       "name":"Grid, time series, or grid sequence file",
       "value":{

--- a/war/data/channels_diff_wave.json
+++ b/war/data/channels_diff_wave.json
@@ -50,268 +50,688 @@
   ],
   "parameters":[
     {
-      "key":"separator",
-      "name":"Run Parameters",
-      "description":"Run",
       "value":{
-        "type":"string",
-        "default":""
-      }
+        "default":"",
+        "type":"string"
+      },
+      "name":"Run",
+      "key":"separator",
+      "description":"Run"
     },
     {
+      "value":{
+        "default":3600,
+        "units":"s",
+        "range":{
+          "max":3153600000,
+          "min":0
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Simulation run time",
       "key":"run_duration",
-      "name":"Run duration",
-      "description":"Simulation run time",
+      "description":"Simulation run time"
+    },
+    {
       "value":{
-        "type":"int",
-        "default":1,
+        "default":600.0,
+        "units":"s",
         "range":{
-          "min":0,
-          "max":1000000
+          "max":31536000.0,
+          "min":1.0
         },
-        "units":"d"
-      }
+        "type":"float"
+      },
+      "visible":true,
+      "name":"Model time step",
+      "key":"dt",
+      "description":"Model time step"
     },
     {
-      "key":"site_prefix",
-      "name":"Site prefix",
-      "description":"File prefix for the study site",
       "value":{
-        "type":"string",
-        "default":"Treynor",
-        "units":"-"
-      }
+        "default":600,
+        "range":{
+          "max":1000000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Number of time steps between port updates",
+      "key":"update_time_step",
+      "description":"Number of time steps between port updates"
     },
     {
-      "key":"case_prefix",
-      "name":"Case prefix",
-      "description":"File prefix for the model scenario",
       "value":{
-        "type":"string",
-        "default":"Case5",
-        "units":"-"
-      }
+        "default":600,
+        "range":{
+          "max":1000000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Number of time steps between output files",
+      "key":"output_interval",
+      "description":"Number of time steps between output files"
     },
     {
-      "key":"separator",
+      "value":{
+        "default":"netcdf",
+        "type":"choice",
+        "choices":[
+          "netcdf",
+          "vtk"
+        ]
+      },
+      "visible":true,
+      "name":"File format for output files",
+      "key":"output_format",
+      "description":"File format for output files"
+    },
+    {
+      "value":{
+        "default":"",
+        "type":"string"
+      },
       "name":"Input",
-      "description":"Input",
-      "value":{
-        "type":"string",
-        "default":""
-      }
+      "key":"separator",
+      "description":"Input"
     },
     {
+      "value":{
+        "default":"site.rti",
+        "files":[
+          "site.rti"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"RiverTools info file",
+      "key":"rti_file",
+      "description":"RiverTools info file"
+    },
+    {
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"Monitored pixel/grid file",
+      "key":"pixel_file",
+      "description":"Monitored pixel/grid file"
+    },
+    {
+      "value":{
+        "default":"site_flow.rtg",
+        "files":[
+          "site_flow.rtg"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"RiverTools grid file of D8 flow codes",
       "key":"code_file",
-      "name":"D8 flow code file",
-      "description":"Grid of d8 flow codes in binary file (jenson 84)",
-      "value":{
-        "type":"string",
-        "default":"[site_prefix]_flow.rtg",
-        "units":"-"
-      }
+      "description":"RiverTools grid file of D8 flow codes"
     },
     {
+      "value":{
+        "default":"site_slope.rtg",
+        "files":[
+          "site_slope.rtg"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"RiverTools grid file of D8 slopes",
       "key":"slope_file",
-      "name":"D8 slope file",
-      "description":"Grid of d8 slopes in binary file",
-      "value":{
-        "type":"string",
-        "default":"[site_prefix]_slope.rtg",
-        "units":"m/m"
-      }
+      "description":"RiverTools grid file of D8 slopes"
     },
     {
-      "key":"MANNING",
-      "name":"Manning flag",
-      "description":"Option to use manning's n for roughness",
       "value":{
-        "type":"int",
-        "default":"1",
+        "default":"Manning's formula",
+        "type":"choice",
+        "choices":[
+          "Manning's formula",
+          "Law of the wall"
+        ]
+      },
+      "visible":true,
+      "name":"Roughness option",
+      "key":"roughness_option",
+      "description":"Roughness option"
+    },
+    {
+      "group":{
+        "name":"roughness_group",
+        "members":3,
+        "leader":true
+      },
+      "name":"Roughness value (Manning's <em>n</em> or roughness length <em>z<sub>0</sub></em>)",
+      "value":{
+        "default":"Scalar",
+        "units":"m-(1/3) s or m",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"roughness_ptype",
+      "description":"Roughness value (Manning's <em>n</em> or roughness length <em>z<sub>0</sub></em>)"
+    },
+    {
+      "group":{
+        "name":"roughness_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.1,
         "range":{
-          "min":"0",
-          "max":"1"
+          "max":5.0,
+          "min":0.0
         },
-        "units":"-"
-      }
+        "type":"float"
+      },
+      "visible":true,
+      "key":"roughness",
+      "description":"Scalar value"
     },
     {
-      "key":"LAW_OF_WALL",
-      "name":"Law of Wall flag",
-      "description":"Option to use law of wall for roughness",
+      "group":{
+        "name":"roughness_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Grid, time series, or grid sequence file",
       "value":{
-        "type":"int",
-        "default":"0",
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"roughness_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "group":{
+        "name":"width_group",
+        "members":3,
+        "leader":true
+      },
+      "name":"Bed width of trapezoid cross-section",
+      "value":{
+        "default":"Scalar",
+        "units":"m",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"width_ptype",
+      "description":"Bed width of trapezoid cross-section"
+    },
+    {
+      "group":{
+        "name":"width_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":10.0,
         "range":{
-          "min":"0",
-          "max":"1"
+          "max":"1E4",
+          "min":0.0
         },
-        "units":"-"
-      }
-    },
-    {
-      "key":"nval_type",
-      "name":"Manning N type",
-      "description":"Allowed input types",
-      "value":{
-        "type":"choice",
-        "default":"Grid",
-        "choices":[
-          "Scalar",
-          "Grid",
-          "Time_Series",
-          "Grid_Sequence"
-        ],
-        "units":"-"
-      }
-    },
-    {
-      "key":"nval",
-      "name":"Manning N",
-      "description":"Manning's n values",
-      "value":{
-        "type":"string",
-        "default":"[site_prefix]_chan-n.rtg",
-        "units":"s/m^(1/3)"
-      }
-    },
-    {
-      "key":"z0val_type",
-      "name":"Roughness z0 type",
-      "description":"Allowed input types",
-      "value":{
-        "type":"choice",
-        "default":"Grid",
-        "choices":[
-          "Scalar",
-          "Grid",
-          "Time_Series",
-          "Grid_Sequence"
-        ],
-        "units":"-"
-      }
-    },
-    {
-      "key":"z0val",
-      "name":"Roughness z0",
-      "description":"Law-of-wall roughness values",
-      "value":{
-        "type":"string",
-        "default":"[site_prefix]_chan-z0.rtg",
-        "units":"m"
-      }
-    },
-    {
-      "key":"width_type",
-      "name":"Bed width type",
-      "description":"Allowed input types",
-      "value":{
-        "type":"choice",
-        "default":"Grid",
-        "choices":[
-          "Scalar",
-          "Grid",
-          "Time_Series",
-          "Grid_Sequence"
-        ],
-        "units":"-"
-      }
-    },
-    {
+        "type":"float"
+      },
+      "visible":true,
       "key":"width",
-      "name":"Bed width",
-      "description":"Bottom width of trapezoid cross-section",
-      "value":{
-        "type":"string",
-        "default":"[site_prefix]_chan-w.rtg",
-        "units":"m"
-      }
+      "description":"Scalar value"
     },
     {
-      "key":"angle_type",
-      "name":"Bank angle type",
-      "description":"Allowed input types",
+      "group":{
+        "name":"width_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Grid, time series, or grid sequence file",
       "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"width_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "group":{
+        "name":"angle_group",
+        "members":3,
+        "leader":true
+      },
+      "name":"Bank angle of trapezoid cross-section",
+      "value":{
+        "default":"Scalar",
+        "units":"deg",
         "type":"choice",
-        "default":"Grid",
         "choices":[
           "Scalar",
           "Grid",
           "Time_Series",
           "Grid_Sequence"
-        ],
-        "units":"-"
-      }
+        ]
+      },
+      "visible":true,
+      "key":"angle_ptype",
+      "description":"Bank angle of trapezoid cross-section"
     },
     {
+      "group":{
+        "name":"angle_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":1.0,
+        "range":{
+          "max":360.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
       "key":"angle",
-      "name":"Bank angle",
-      "description":"Bank angle of trapezoid cross-section",
-      "value":{
-        "type":"string",
-        "default":"[site_prefix]_chan-a.rtg",
-        "units":"deg"
-      }
+      "description":"Scalar value"
     },
     {
-      "key":"d0_type",
-      "name":"Init. depth type",
-      "description":"Allowed input types",
+      "group":{
+        "name":"angle_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Grid, time series, or grid sequence file",
       "value":{
-        "type":"choice",
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"angle_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "group":{
+        "name":"d0_group",
+        "members":3,
+        "leader":true
+      },
+      "name":"Initial flow depth",
+      "value":{
         "default":"Scalar",
+        "units":"m",
+        "type":"choice",
         "choices":[
           "Scalar",
           "Grid",
           "Time_Series",
           "Grid_Sequence"
-        ],
-        "units":"-"
-      }
+        ]
+      },
+      "visible":true,
+      "key":"d0_ptype",
+      "description":"Initial flow depth"
     },
     {
+      "group":{
+        "name":"d0_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.0,
+        "range":{
+          "max":0.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
       "key":"d0",
-      "name":"Init. depth",
-      "description":"Initial flow depth (if scalar, use 0.0!)",
-      "value":{
-        "type":"float",
-        "default":"0.00000000",
-        "range":{
-          "min":"0.0",
-          "max":"0.1"
-        },
-        "units":"m"
-      }
+      "description":"Scalar value"
     },
     {
-      "key":"sinu_type",
-      "name":"Sinuosity type",
-      "description":"Allowed input types",
+      "group":{
+        "name":"d0_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Grid, time series, or grid sequence file",
       "value":{
-        "type":"choice",
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"d0_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "group":{
+        "name":"sinu_group",
+        "members":3,
+        "leader":true
+      },
+      "name":"Absolute channel sinuosity",
+      "value":{
         "default":"Scalar",
+        "units":"m m-1",
+        "type":"choice",
         "choices":[
           "Scalar",
           "Grid",
           "Time_Series",
           "Grid_Sequence"
-        ],
-        "units":"-"
-      }
+        ]
+      },
+      "visible":true,
+      "key":"sinu_ptype",
+      "description":"Absolute channel sinuosity"
     },
     {
-      "key":"sinu",
-      "name":"Sinuosity",
-      "description":"Absolute channel sinuosity",
+      "group":{
+        "name":"sinu_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Scalar value",
       "value":{
-        "type":"float",
-        "default":"1.00000000",
+        "default":1.0,
         "range":{
-          "min":"0.0",
-          "max":"3.0"
+          "max":3.0,
+          "min":0.0
         },
-        "units":"m/m"
-      }
+        "type":"float"
+      },
+      "visible":true,
+      "key":"sinu",
+      "description":"Scalar value"
+    },
+    {
+      "group":{
+        "name":"sinu_group",
+        "members":3,
+        "leader":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"sinu_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Bank angle of trapezoid cross-section data type",
+      "key":"angle_dtype",
+      "description":"Bank angle of trapezoid cross-section data type"
+    },
+    {
+      "value":{
+        "default":"case",
+        "units":"-",
+        "type":"string"
+      },
+      "visible":false,
+      "name":"File prefix for the model scenario",
+      "key":"case_prefix",
+      "description":"File prefix for the model scenario"
+    },
+    {
+      "value":{
+        "default":0.1,
+        "units":"m",
+        "range":{
+          "max":5.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":false,
+      "name":"Law-of-wall roughness value",
+      "key":"z0val",
+      "description":"Law-of-wall roughness value"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Absolute channel sinuosity data type",
+      "key":"sinu_dtype",
+      "description":"Absolute channel sinuosity data type"
+    },
+    {
+      "value":{
+        "default":"Scalar",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":false,
+      "name":"Law-of-wall roughness values",
+      "key":"z0val_ptype",
+      "description":"Law-of-wall roughness values"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Manning's n value data type",
+      "key":"nval_dtype",
+      "description":"Manning's n value data type"
+    },
+    {
+      "value":{
+        "default":0,
+        "units":"-",
+        "range":{
+          "max":1,
+          "min":0
+        },
+        "type":"int"
+      },
+      "visible":false,
+      "name":"Option to use mannings n for roughness",
+      "key":"MANNING",
+      "description":"Option to use mannings n for roughness"
+    },
+    {
+      "value":{
+        "default":"site",
+        "units":"-",
+        "type":"string"
+      },
+      "visible":false,
+      "name":"File prefix for the study site",
+      "key":"site_prefix",
+      "description":"File prefix for the study site"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Initial flow depth data type",
+      "key":"d0_dtype",
+      "description":"Initial flow depth data type"
+    },
+    {
+      "value":{
+        "default":0.1,
+        "units":"s/m^(1/3)",
+        "range":{
+          "max":5.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":false,
+      "name":"Mannings n value",
+      "key":"nval",
+      "description":"Mannings n value"
+    },
+    {
+      "value":{
+        "default":"Scalar",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":false,
+      "name":"Mannings n value",
+      "key":"nval_ptype",
+      "description":"Mannings n value"
+    },
+    {
+      "value":{
+        "default":3600,
+        "units":"-",
+        "range":{
+          "max":3153600000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":false,
+      "name":"Number of time steps",
+      "key":"n_steps",
+      "description":"Number of time steps"
+    },
+    {
+      "value":{
+        "default":0,
+        "units":"-",
+        "range":{
+          "max":1,
+          "min":0
+        },
+        "type":"int"
+      },
+      "visible":false,
+      "name":"Option to use law of wall for roughness",
+      "key":"LAW_OF_WALL",
+      "description":"Option to use law of wall for roughness"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Law-of-wall roughness value data type",
+      "key":"z0val_dtype",
+      "description":"Law-of-wall roughness value data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Bed width of trapezoid cross-section data type",
+      "key":"width_dtype",
+      "description":"Bed width of trapezoid cross-section data type"
     }
   ]
 }


### PR DESCRIPTION
I've introduced a new parameter datatype, `selection`, which can be used when the type of a parameter depends on the choice of another. This datatype is meant to be generic, but it was created for TopoFlow, where a parameter can be of type scalar, time series, grid, or grid sequence.

The related `group` parameter datatype remains unchanged.