### PR TITLE
Display global parameters only in driver component

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/control/ModelSerializer.java
+++ b/src/edu/colorado/csdms/wmt/client/control/ModelSerializer.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.control;
 
 import java.util.ArrayList;
@@ -247,8 +224,7 @@ public class ModelSerializer {
     // If this is the driver, show its parameters in the ParameterTable. Also
     // display the name of the model.
     if (modelComponent.isDriver()) {
-      data.getPerspective().getParameterTable().loadTable(
-          modelComponent.getId());
+      data.getPerspective().getParameterTable().loadTable(cell);
       data.getPerspective().setModelPanelTitle();
     }
 

--- a/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
+++ b/src/edu/colorado/csdms/wmt/client/data/ParameterJSO.java
@@ -150,6 +150,14 @@ public class ParameterJSO extends JavaScriptObject {
   }-*/;
 
   /**
+   * A JSNI method to get the "global" attribute of a parameter, a JS boolean.
+   * If the attribute doesn't exist, false is returned.
+   */
+  public final native boolean isGlobal() /*-{
+    return this.global || false;
+  }-*/;
+
+  /**
    * A non-JSNI method for stringifying the attributes of a ParameterJSO. Must
    * be final.
    */

--- a/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
@@ -31,7 +31,6 @@ public class ParameterTable extends FlexTable {
   public DataManager data;
   private String componentId; // the id of the displayed component
   private ComponentCell cell; // the corresponding cell in the ModelTree
-  private ParameterActionPanel actionPanel;
   private Integer tableRowIndex; // where we are in table
   private Integer parameterIndex; // where we are in list of parameters
 
@@ -89,7 +88,8 @@ public class ParameterTable extends FlexTable {
    * {@link ParameterTable}.
    */
   private void addActionPanel() {
-    actionPanel = new ParameterActionPanel(data, componentId);
+    ParameterActionPanel actionPanel =
+        new ParameterActionPanel(data, componentId);
     actionPanel.getElement().getStyle().setMarginTop(-3.0, Unit.PX);
     this.setWidget(tableRowIndex, 0, actionPanel);
     tableRowIndex++;

--- a/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
@@ -15,14 +15,14 @@ import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import edu.colorado.csdms.wmt.client.control.DataManager;
 import edu.colorado.csdms.wmt.client.data.ParameterJSO;
 import edu.colorado.csdms.wmt.client.ui.cell.ChoiceCell;
+import edu.colorado.csdms.wmt.client.ui.cell.ComponentCell;
 import edu.colorado.csdms.wmt.client.ui.cell.DescriptionCell;
 import edu.colorado.csdms.wmt.client.ui.cell.SeparatorCell;
 import edu.colorado.csdms.wmt.client.ui.cell.ValueCell;
 import edu.colorado.csdms.wmt.client.ui.panel.ParameterActionPanel;
 
 /**
- * Builds a table of parameters for a single WMT model component. The value of
- * the parameter is editable.
+ * Builds and displays a table of parameters for a single WMT model component.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */
@@ -30,13 +30,14 @@ public class ParameterTable extends FlexTable {
 
   public DataManager data;
   private String componentId; // the id of the displayed component
+  private ComponentCell cell; // the corresponding cell in the ModelTree
   private ParameterActionPanel actionPanel;
   private Integer tableRowIndex; // where we are in table
   private Integer parameterIndex; // where we are in list of parameters
 
   /**
    * Initializes a table of parameters for a single WMT model component. The
-   * table is empty until {@link #loadTable(String)} is called.
+   * table is empty until {@link #loadTable(ComponentCell)} is called.
    * 
    * @param data the DataManager instance for the WMT session
    */
@@ -52,22 +53,22 @@ public class ParameterTable extends FlexTable {
    * A worker that loads the ParameterTable with parameter values for the
    * selected model component.
    * 
-   * @param componentId the id of the component whose parameters are to be
-   *  displayed
+   * @param cell the {@link ComponentCell} of the component whose parameters are
+   *          to be displayed
    */
-  public void loadTable(String componentId) {
+  public void loadTable(ComponentCell cell) {
 
     // Always clear the table before building it.
     this.clearTable();
+
+    this.cell = cell;
+    this.componentId = cell.getComponentId();
 
     // Return if the selected component doesn't have parameters.
     if (data.getModelComponent(componentId).getParameters() == null) {
       Window.alert("No parameters defined for this component.");
       return;
     }
-
-    // The component whose parameters are to be displayed.
-    this.setComponentId(componentId);
 
     // Set the component name on the tab holding the ParameterTable.
     data.getPerspective().setParameterPanelTitle(componentId);
@@ -103,16 +104,21 @@ public class ParameterTable extends FlexTable {
     ParameterJSO parameter =
         data.getModelComponent(componentId).getParameters().get(parameterIndex);
 
-    // Short-circuit if the parameter isn't visible.
+    // Return if the parameter isn't visible.
     if (!parameter.isVisible()) {
       return;
     }
 
-    // Short circuit if the parameter is a separator.
+    // Return if the parameter is a separator.
     if (parameter.getKey().matches("separator")) {
       this.setWidget(tableRowIndex, 0, new SeparatorCell(parameter));
       this.getFlexCellFormatter().setColSpan(tableRowIndex, 0, 3);
       tableRowIndex++;
+      return;
+    }
+
+    // Return if the parameter is global and the component is not the driver.
+    if (parameter.isGlobal() && !cell.getPortId().matches("driver")) {
       return;
     }
 

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ComponentSelectionCommand.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ComponentSelectionCommand.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.handler;
 
 import com.google.gwt.core.client.GWT;
@@ -112,7 +89,7 @@ public class ComponentSelectionCommand implements Command {
     // If this is the driver, display the component's parameters.
     if (isDriver) {
       data.setShowingParameters(cell);
-      data.getPerspective().getParameterTable().loadTable(componentId);
+      data.getPerspective().getParameterTable().loadTable(cell);
     }
 
     // Update the tooltip text.

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ComponentShowParametersCommand.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ComponentShowParametersCommand.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.handler;
 
 import com.google.gwt.core.shared.GWT;
@@ -57,7 +34,7 @@ public class ComponentShowParametersCommand implements Command {
   @Override
   public void execute() {
     GWT.log("Show parameters for: " + data.getComponent(componentId).getName());
-    data.getPerspective().getParameterTable().loadTable(componentId);
+    data.getPerspective().getParameterTable().loadTable(cell);
     ComponentCell wasShowingParameters = data.getShowingParameters();
     wasShowingParameters.removeStyleDependentName("showingParameters");
     data.setShowingParameters(cell);

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ParameterActionPanelResetHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ParameterActionPanelResetHandler.java
@@ -5,6 +5,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 
 import edu.colorado.csdms.wmt.client.Constants;
 import edu.colorado.csdms.wmt.client.control.DataManager;
+import edu.colorado.csdms.wmt.client.ui.cell.ComponentCell;
 import edu.colorado.csdms.wmt.client.ui.dialog.QuestionDialogBox;
 
 /**
@@ -42,7 +43,8 @@ public class ParameterActionPanelResetHandler implements ClickHandler {
             questionDialog.hide();
             data.replaceModelComponent(data.getComponent(componentId));
             data.getPerspective().getParameterTable().clearTable();
-            data.getPerspective().getParameterTable().loadTable(componentId);
+            ComponentCell cell = data.getShowingParameters();
+            data.getPerspective().getParameterTable().loadTable(cell);
             data.updateModelSaveState(false);
           }
         });

--- a/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
+++ b/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
@@ -218,6 +218,11 @@ public class ParameterJSOTest extends GWTTestCase {
   }
 
   @Test
+  public void testIsNotGlobal() {
+    assertFalse(groupParam.isGlobal());
+  }
+
+  @Test
   public void testGetValue() {
     assertSame(value, basicParam.getValue());
   }

--- a/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
+++ b/test/edu/colorado/csdms/wmt/client/ParameterJSOTest.java
@@ -30,6 +30,7 @@ public class ParameterJSOTest extends GWTTestCase {
   private String name;
   private String description;
   private Boolean visible;
+  private Boolean global;
   private String groupName;
   private Boolean groupLeader;
   private Integer groupMembers;
@@ -49,12 +50,13 @@ public class ParameterJSOTest extends GWTTestCase {
    * {@link ParameterJSO} object.
    */
   private native ParameterJSO testBasicParameterJSO(String key, String name,
-      String description, Boolean visible, ValueJSO value) /*-{
+      String description, Boolean visible, Boolean global, ValueJSO value) /*-{
 		return {
 			"key" : key,
 			"name" : name,
 			"description" : description,
 			"visible" : visible,
+			"global" : global,
 			"value" : value
 		};
   }-*/;
@@ -127,8 +129,10 @@ public class ParameterJSOTest extends GWTTestCase {
     selectionSelector = true;
     selectionMembers = 9467;
     visible = true;
+    global = true;
     value = testValueJSO();
-    basicParam = testBasicParameterJSO(key, name, description, visible, value);
+    basicParam =
+        testBasicParameterJSO(key, name, description, visible, global, value);
     groupParam =
         testGroupParameterJSO(key, name, description, groupName, groupLeader,
             groupMembers, value);
@@ -206,6 +210,11 @@ public class ParameterJSOTest extends GWTTestCase {
   public void testSetIsVisible() {
     basicParam.isVisible(false);
     assertFalse(basicParam.isVisible());
+  }
+
+  @Test
+  public void testIsGlobal() {
+    assertTrue(basicParam.isGlobal());
   }
 
   @Test

--- a/war/data/channels_diff_wave.json
+++ b/war/data/channels_diff_wave.json
@@ -65,6 +65,7 @@
         "type":"int"
       },
       "visible":true,
+      "global":true,
       "name":"Simulation run time",
       "key":"run_duration",
       "description":"Simulation run time"

--- a/war/data/channels_diff_wave.json
+++ b/war/data/channels_diff_wave.json
@@ -36,10 +36,6 @@
     },
     {
       "required":false,
-      "id":"ice"
-    },
-    {
-      "required":false,
       "id":"diversions"
     }
   ],

--- a/war/data/components.json
+++ b/war/data/components.json
@@ -7,6 +7,7 @@
   "child",
   "coastal_environment",
   "hydrotrend",
+  "meteorology",
   "plume",
   "sedflux2d",
   "sedflux3d",

--- a/war/data/components.json
+++ b/war/data/components.json
@@ -10,6 +10,7 @@
   "plume",
   "sedflux2d",
   "sedflux3d",
+  "snow_degree_day",
   "vector_parameter_study",
   "waves"
 ]

--- a/war/data/meteorology.json
+++ b/war/data/meteorology.json
@@ -1,0 +1,1629 @@
+{
+  "id":"meteorology",
+  "files":[
+    
+  ],
+  "doi":"10.1594/IEDA/100174",
+  "name":"Meteorology",
+  "license":"Apache",
+  "author":"Scott Peckham",
+  "url":"http://csdms.colorado.edu/wiki/Model_help:TopoFlow-Meteorology",
+  "argv":[
+    
+  ],
+  "summary":"This process component is part of a spatially-distributed hydrologic model called TopoFlow, but it can now be used as a stand-alone model.",
+  "version":"3.1",
+  "uses":[
+    {
+      "required":false,
+      "id":"snow"
+    }
+  ],
+  "provides":[
+    {
+      "id":"meteorology"
+    }
+  ],
+  "parameters":[
+    {
+      "value":{
+        "default":"",
+        "type":"string"
+      },
+      "name":"Run",
+      "key":"separator",
+      "description":"Run"
+    },
+    {
+      "value":{
+        "default":3600,
+        "units":"s",
+        "range":{
+          "max":3153600000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "global":true,
+      "name":"Simulation run time",
+      "key":"run_duration",
+      "description":"Simulation run time"
+    },
+    {
+      "value":{
+        "default":600.0,
+        "units":"s",
+        "range":{
+          "max":31536000.0,
+          "min":1.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "name":"Model time step",
+      "key":"dt",
+      "description":"Model time step"
+    },
+    {
+      "value":{
+        "default":600,
+        "range":{
+          "max":1000000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Number of time steps between port updates",
+      "key":"update_time_step",
+      "description":"Number of time steps between port updates"
+    },
+    {
+      "value":{
+        "default":600,
+        "range":{
+          "max":1000000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Number of time steps between output files",
+      "key":"output_interval",
+      "description":"Number of time steps between output files"
+    },
+    {
+      "value":{
+        "default":"netcdf",
+        "type":"choice",
+        "choices":[
+          "netcdf",
+          "vtk"
+        ]
+      },
+      "visible":true,
+      "name":"File format for output files",
+      "key":"output_format",
+      "description":"File format for output files"
+    },
+    {
+      "value":{
+        "default":"",
+        "type":"string"
+      },
+      "name":"Input",
+      "key":"separator",
+      "description":"Input"
+    },
+    {
+      "value":{
+        "default":"site.rti",
+        "files":[
+          "site.rti"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"RiverTools info file",
+      "key":"rti_file",
+      "description":"RiverTools info file"
+    },
+    {
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"Monitored pixel/grid file (outlets)",
+      "key":"pixel_file",
+      "description":"Monitored pixel/grid file (outlets)"
+    },
+    {
+      "value":{
+        "default":"No",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Yes",
+          "No"
+        ]
+      },
+      "visible":true,
+      "name":"Turn off all variable updates except precipitation",
+      "key":"PRECIP_ONLY",
+      "description":"Turn off all variable updates except precipitation"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"rho_H2O",
+          "Time_Series":"rho_H2O_file",
+          "Grid":"rho_H2O_file",
+          "Grid_Sequence":"rho_H2O_file"
+        },
+        "name":"rho_H2O_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Density of water",
+      "value":{
+        "default":"Scalar",
+        "units":"kg m-3",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"rho_H2O_ptype",
+      "description":"Density of water"
+    },
+    {
+      "selection":{
+        "name":"rho_H2O_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":1000.0,
+        "range":{
+          "max":2000.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"rho_H2O",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"rho_H2O_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"rho_H2O_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"Cp_air",
+          "Time_Series":"Cp_air_file",
+          "Grid":"Cp_air_file",
+          "Grid_Sequence":"Cp_air_file"
+        },
+        "name":"Cp_air_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Heat capacity of air",
+      "value":{
+        "default":"Scalar",
+        "units":"J kg-1 K-1",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"Cp_air_ptype",
+      "description":"Heat capacity of air"
+    },
+    {
+      "selection":{
+        "name":"Cp_air_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":1005.7,
+        "range":{
+          "max":2000.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"Cp_air",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"Cp_air_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"Cp_air_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"rho_air",
+          "Time_Series":"rho_air_file",
+          "Grid":"rho_air_file",
+          "Grid_Sequence":"rho_air_file"
+        },
+        "name":"rho_air_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Density of air",
+      "value":{
+        "default":"Scalar",
+        "units":"kg m-3",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"rho_air_ptype",
+      "description":"Density of air"
+    },
+    {
+      "selection":{
+        "name":"rho_air_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":1.26139998,
+        "range":{
+          "max":2.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"rho_air",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"rho_air_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"rho_air_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"P",
+          "Time_Series":"P_file",
+          "Grid":"P_file",
+          "Grid_Sequence":"P_file"
+        },
+        "name":"P_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Precipitation rate",
+      "value":{
+        "default":"Scalar",
+        "units":"mm hr-1",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"P_ptype",
+      "description":"Precipitation rate"
+    },
+    {
+      "selection":{
+        "name":"P_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.0,
+        "range":{
+          "max":5000.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"P",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"P_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"P_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"T_air",
+          "Time_Series":"T_air_file",
+          "Grid":"T_air_file",
+          "Grid_Sequence":"T_air_file"
+        },
+        "name":"T_air_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Temperature of air",
+      "value":{
+        "default":"Scalar",
+        "units":"degC",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"T_air_ptype",
+      "description":"Temperature of air"
+    },
+    {
+      "selection":{
+        "name":"T_air_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":20.0,
+        "range":{
+          "max":150.0,
+          "min":-100.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"T_air",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"T_air_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"T_air_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"T_surf",
+          "Time_Series":"T_surf_file",
+          "Grid":"T_surf_file",
+          "Grid_Sequence":"T_surf_file"
+        },
+        "name":"T_surf_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Temperature at surface",
+      "value":{
+        "default":"Scalar",
+        "units":"degC",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"T_surf_ptype",
+      "description":"Temperature at surface"
+    },
+    {
+      "selection":{
+        "name":"T_surf_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":-5.0,
+        "range":{
+          "max":150.0,
+          "min":-100.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"T_surf",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"T_surf_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"T_surf_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"RH",
+          "Time_Series":"RH_file",
+          "Grid":"RH_file",
+          "Grid_Sequence":"RH_file"
+        },
+        "name":"RH_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Relative humidity",
+      "value":{
+        "default":"Scalar",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"RH_ptype",
+      "description":"Relative humidity"
+    },
+    {
+      "selection":{
+        "name":"RH_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.5,
+        "range":{
+          "max":1.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"RH",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"RH_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"RH_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"p0",
+          "Time_Series":"p0_file",
+          "Grid":"p0_file",
+          "Grid_Sequence":"p0_file"
+        },
+        "name":"p0_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Atmospheric pressure",
+      "value":{
+        "default":"Scalar",
+        "units":"mbar",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"p0_ptype",
+      "description":"Atmospheric pressure"
+    },
+    {
+      "selection":{
+        "name":"p0_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":1000.0,
+        "range":{
+          "max":1500.0,
+          "min":750.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"p0",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"p0_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"p0_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"z",
+          "Time_Series":"z_file",
+          "Grid":"z_file",
+          "Grid_Sequence":"z_file"
+        },
+        "name":"z_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Wind reference height",
+      "value":{
+        "default":"Scalar",
+        "units":"m",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"z_ptype",
+      "description":"Wind reference height"
+    },
+    {
+      "selection":{
+        "name":"z_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":10.0,
+        "range":{
+          "max":1000.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"z",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"z_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"z_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"uz",
+          "Time_Series":"uz_file",
+          "Grid":"uz_file",
+          "Grid_Sequence":"uz_file"
+        },
+        "name":"uz_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Wind velocity at reference height",
+      "value":{
+        "default":"Scalar",
+        "units":"m s-1",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"uz_ptype",
+      "description":"Wind velocity at reference height"
+    },
+    {
+      "selection":{
+        "name":"uz_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":3.0,
+        "range":{
+          "max":20.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"uz",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"uz_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"uz_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"z0_air",
+          "Time_Series":"z0_air_file",
+          "Grid":"z0_air_file",
+          "Grid_Sequence":"z0_air_file"
+        },
+        "name":"z0_air_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Surface roughness length scale for wind",
+      "value":{
+        "default":"Scalar",
+        "units":"m",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"z0_air_ptype",
+      "description":"Surface roughness length scale for wind"
+    },
+    {
+      "selection":{
+        "name":"z0_air_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.02,
+        "range":{
+          "max":"1E2",
+          "min":"1E-4"
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"z0_air",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"z0_air_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"z0_air_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"albedo",
+          "Time_Series":"albedo_file",
+          "Grid":"albedo_file",
+          "Grid_Sequence":"albedo_file"
+        },
+        "name":"albedo_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Surface albedo",
+      "value":{
+        "default":"Scalar",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"albedo_ptype",
+      "description":"Surface albedo"
+    },
+    {
+      "selection":{
+        "name":"albedo_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.8,
+        "range":{
+          "max":1.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"albedo",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"albedo_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"albedo_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"em_surf",
+          "Time_Series":"em_surf_file",
+          "Grid":"em_surf_file",
+          "Grid_Sequence":"em_surf_file"
+        },
+        "name":"em_surf_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Surface emissivity",
+      "value":{
+        "default":"Scalar",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"em_surf_ptype",
+      "description":"Surface emissivity"
+    },
+    {
+      "selection":{
+        "name":"em_surf_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.98,
+        "range":{
+          "max":1.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"em_surf",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"em_surf_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"em_surf_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"dust_atten",
+          "Time_Series":"dust_atten_file",
+          "Grid":"dust_atten_file",
+          "Grid_Sequence":"dust_atten_file"
+        },
+        "name":"dust_atten_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Dust attenuation factor",
+      "value":{
+        "default":"Scalar",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"dust_atten_ptype",
+      "description":"Dust attenuation factor"
+    },
+    {
+      "selection":{
+        "name":"dust_atten_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.08,
+        "range":{
+          "max":0.3,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"dust_atten",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"dust_atten_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"dust_atten_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"cloud_factor",
+          "Time_Series":"cloud_factor_file",
+          "Grid":"cloud_factor_file",
+          "Grid_Sequence":"cloud_factor_file"
+        },
+        "name":"cloud_factor_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Cloudiness factor, <i>c</i>",
+      "value":{
+        "default":"Scalar",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"cloud_factor_ptype",
+      "description":"Cloudiness factor, <i>c</i>"
+    },
+    {
+      "selection":{
+        "name":"cloud_factor_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.0,
+        "range":{
+          "max":1.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"cloud_factor",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"cloud_factor_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"cloud_factor_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"canopy_factor",
+          "Time_Series":"canopy_factor_file",
+          "Grid":"canopy_factor_file",
+          "Grid_Sequence":"canopy_factor_file"
+        },
+        "name":"canopy_factor_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Canopy coverage factor, <i>f</i>",
+      "value":{
+        "default":"Scalar",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"canopy_factor_ptype",
+      "description":"Canopy coverage factor, <i>f</i>"
+    },
+    {
+      "selection":{
+        "name":"canopy_factor_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.0,
+        "range":{
+          "max":1.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"canopy_factor",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"canopy_factor_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"canopy_factor_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "value":{
+        "default":"site_slope.rtg",
+        "files":[
+          "site_slope.rtg"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"Slope grid file (flat binary file, row-major grid, 4-byte values)",
+      "key":"slope_grid_file",
+      "description":"Slope grid file (flat binary file, row-major grid, 4-byte values)"
+    },
+    {
+      "value":{
+        "default":"site_aspect.rtg",
+        "files":[
+          "site_aspect.rtg"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"Aspect grid file (flat binary file, row-major grid, 4-byte values)",
+      "key":"aspect_grid_file",
+      "description":"Aspect grid file (flat binary file, row-major grid, 4-byte values)"
+    },
+    {
+      "value":{
+        "default":"0",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "-12",
+          "-11",
+          "-10",
+          "-9",
+          "-8",
+          "-7",
+          "-6",
+          "-5",
+          "-4",
+          "-3",
+          "-2",
+          "-1",
+          "0",
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+          "6",
+          "7",
+          "8",
+          "9",
+          "10",
+          "11",
+          "12"
+        ]
+      },
+      "visible":true,
+      "name":"Time zone offset from GMT",
+      "key":"GMT_offset",
+      "description":"Time zone offset from GMT"
+    },
+    {
+      "value":{
+        "default":"January",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December"
+        ]
+      },
+      "visible":true,
+      "name":"Start month",
+      "key":"start_month",
+      "description":"Start month"
+    },
+    {
+      "value":{
+        "default":1,
+        "units":"-",
+        "range":{
+          "max":31,
+          "min":0
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Start day",
+      "key":"start_day",
+      "description":"Start day"
+    },
+    {
+      "value":{
+        "default":0.0,
+        "units":"-",
+        "range":{
+          "max":23.99,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "name":"Start hour",
+      "key":"start_hour",
+      "description":"Start hour"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Canopy coverage factor data type",
+      "key":"canopy_factor_dtype",
+      "description":"Canopy coverage factor data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Density of air data type",
+      "key":"rho_air_dtype",
+      "description":"Density of air data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Surface roughness length scale for wind data type",
+      "key":"z0_air_dtype",
+      "description":"Surface roughness length scale for wind data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Temperature of air data type",
+      "key":"T_air_dtype",
+      "description":"Temperature of air data type"
+    },
+    {
+      "value":{
+        "default":"case",
+        "units":"-",
+        "type":"string"
+      },
+      "visible":false,
+      "name":"File prefix for the model scenario",
+      "key":"case_prefix",
+      "description":"File prefix for the model scenario"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Precipitation rate data type",
+      "key":"P_dtype",
+      "description":"Precipitation rate data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Wind reference height data type",
+      "key":"z_dtype",
+      "description":"Wind reference height data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Dust attenuation factor data type",
+      "key":"dust_atten_dtype",
+      "description":"Dust attenuation factor data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Relative humidity data type",
+      "key":"RH_dtype",
+      "description":"Relative humidity data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Surface albedo data type",
+      "key":"albedo_dtype",
+      "description":"Surface albedo data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Temperature at surface data type",
+      "key":"T_surf_dtype",
+      "description":"Temperature at surface data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Cloudiness factor data type",
+      "key":"cloud_factor_dtype",
+      "description":"Cloudiness factor data type"
+    },
+    {
+      "value":{
+        "default":"site",
+        "units":"-",
+        "type":"string"
+      },
+      "visible":false,
+      "name":"File prefix for the study site",
+      "key":"site_prefix",
+      "description":"File prefix for the study site"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Wind velocity at reference height data type",
+      "key":"uz_dtype",
+      "description":"Wind velocity at reference height data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Density of water data type",
+      "key":"rho_H2O_dtype",
+      "description":"Density of water data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Atmospheric pressure data type",
+      "key":"p0_dtype",
+      "description":"Atmospheric pressure data type"
+    },
+    {
+      "value":{
+        "default":3600,
+        "units":"-",
+        "range":{
+          "max":3153600000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":false,
+      "name":"Number of time steps",
+      "key":"n_steps",
+      "description":"Number of time steps"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Surface emissivity data type",
+      "key":"em_surf_dtype",
+      "description":"Surface emissivity data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Heat capacity of air data type",
+      "key":"Cp_air_dtype",
+      "description":"Heat capacity of air data type"
+    }
+  ]
+}

--- a/war/data/snow_degree_day.json
+++ b/war/data/snow_degree_day.json
@@ -1,0 +1,592 @@
+{
+  "id":"snow_degree_day",
+  "files":[
+    
+  ],
+  "doi":"10.1594/IEDA/100174",
+  "name":"SnowDegreeDay",
+  "license":"Apache",
+  "author":"Scott Peckham",
+  "url":"http://csdms.colorado.edu/wiki/Model_help:TopoFlow-Snowmelt-Degree-Day",
+  "argv":[
+    
+  ],
+  "summary":"This process component is part of a spatially-distributed hydrologic model called TopoFlow, but it can now be used as a stand-alone model.",
+  "version":"3.1",
+  "uses":[
+    {
+      "required":false,
+      "id":"meteorology"
+    }
+  ],
+  "provides":[
+    {
+      "id":"snow"
+    }
+  ],
+  "parameters":[
+    {
+      "value":{
+        "default":"",
+        "type":"string"
+      },
+      "name":"Run",
+      "key":"separator",
+      "description":"Run"
+    },
+    {
+      "value":{
+        "default":3600,
+        "units":"s",
+        "range":{
+          "max":3153600000,
+          "min":0
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Simulation run time",
+      "key":"run_duration",
+      "description":"Simulation run time"
+    },
+    {
+      "value":{
+        "default":600,
+        "units":"s",
+        "range":{
+          "max":31536000,
+          "min":1
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "name":"Model time step",
+      "key":"dt",
+      "description":"Model time step"
+    },
+    {
+      "value":{
+        "default":600,
+        "range":{
+          "max":1000000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Number of time steps between port updates",
+      "key":"update_time_step",
+      "description":"Number of time steps between port updates"
+    },
+    {
+      "value":{
+        "default":600,
+        "range":{
+          "max":1000000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":true,
+      "name":"Number of time steps between output files",
+      "key":"output_interval",
+      "description":"Number of time steps between output files"
+    },
+    {
+      "value":{
+        "default":"netcdf",
+        "type":"choice",
+        "choices":[
+          "netcdf",
+          "vtk"
+        ]
+      },
+      "visible":true,
+      "name":"File format for output files",
+      "key":"output_format",
+      "description":"File format for output files"
+    },
+    {
+      "value":{
+        "default":"",
+        "type":"string"
+      },
+      "name":"Input",
+      "key":"separator",
+      "description":"Input"
+    },
+    {
+      "value":{
+        "default":"site.rti",
+        "files":[
+          "site.rti"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"RiverTools info file",
+      "key":"rti_file",
+      "description":"RiverTools info file"
+    },
+    {
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "name":"Monitored pixel/grid file (outlets)",
+      "key":"pixel_file",
+      "description":"Monitored pixel/grid file (outlets)"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"rho_snow",
+          "Time_Series":"rho_snow_file",
+          "Grid":"rho_snow_file",
+          "Grid_Sequence":"rho_snow_file"
+        },
+        "name":"rho_snow_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Density of snow",
+      "value":{
+        "default":"Scalar",
+        "units":"kg m-3",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"rho_snow_ptype",
+      "description":"Density of snow"
+    },
+    {
+      "selection":{
+        "name":"rho_snow_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":300.0,
+        "range":{
+          "max":"1e3",
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"rho_snow",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"rho_snow_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"rho_snow_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"c0",
+          "Time_Series":"c0_file",
+          "Grid":"c0_file",
+          "Grid_Sequence":"c0_file"
+        },
+        "name":"c0_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Degree day coefficient",
+      "value":{
+        "default":"Scalar",
+        "units":"mm d-1 degC-1",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"c0_ptype",
+      "description":"Degree day coefficient"
+    },
+    {
+      "selection":{
+        "name":"c0_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":2.7,
+        "range":{
+          "max":"1e2",
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"c0",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"c0_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"c0_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"T0",
+          "Time_Series":"T0_file",
+          "Grid":"T0_file",
+          "Grid_Sequence":"T0_file"
+        },
+        "name":"T0_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Reference temperature",
+      "value":{
+        "default":"Scalar",
+        "units":"degC",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"T0_ptype",
+      "description":"Reference temperature"
+    },
+    {
+      "selection":{
+        "name":"T0_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":-0.2,
+        "range":{
+          "max":100,
+          "min":-100.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"T0",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"T0_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"T0_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"h0_snow",
+          "Time_Series":"h0_snow_file",
+          "Grid":"h0_snow_file",
+          "Grid_Sequence":"h0_snow_file"
+        },
+        "name":"h0_snow_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Depth of snow",
+      "value":{
+        "default":"Scalar",
+        "units":"m",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"h0_snow_ptype",
+      "description":"Depth of snow"
+    },
+    {
+      "selection":{
+        "name":"h0_snow_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.5,
+        "range":{
+          "max":20.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"h0_snow",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"h0_snow_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"h0_snow_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "selection":{
+        "mapping":{
+          "Scalar":"h0_swe",
+          "Time_Series":"h0_swe_file",
+          "Grid":"h0_swe_file",
+          "Grid_Sequence":"h0_swe_file"
+        },
+        "name":"h0_swe_mapper",
+        "members":3,
+        "selector":true
+      },
+      "name":"Depth of snow water equivalent (SWE)",
+      "value":{
+        "default":"Scalar",
+        "units":"m",
+        "type":"choice",
+        "choices":[
+          "Scalar",
+          "Grid",
+          "Time_Series",
+          "Grid_Sequence"
+        ]
+      },
+      "visible":true,
+      "key":"h0_swe_ptype",
+      "description":"Depth of snow water equivalent (SWE)"
+    },
+    {
+      "selection":{
+        "name":"h0_swe_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Scalar value",
+      "value":{
+        "default":0.15,
+        "range":{
+          "max":20.0,
+          "min":0.0
+        },
+        "type":"float"
+      },
+      "visible":true,
+      "key":"h0_swe",
+      "description":"Scalar value"
+    },
+    {
+      "selection":{
+        "name":"h0_swe_mapper",
+        "members":3,
+        "selector":false
+      },
+      "name":"Grid, time series, or grid sequence file",
+      "value":{
+        "default":"off",
+        "files":[
+          "off"
+        ],
+        "type":"file"
+      },
+      "visible":true,
+      "key":"h0_swe_file",
+      "description":"Grid, time series, or grid sequence file"
+    },
+    {
+      "value":{
+        "default":"case",
+        "units":"-",
+        "type":"string"
+      },
+      "visible":false,
+      "name":"File prefix for the model scenario",
+      "key":"case_prefix",
+      "description":"File prefix for the model scenario"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Reference temperature data type",
+      "key":"T0_dtype",
+      "description":"Reference temperature data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Depth of snow data type",
+      "key":"h0_snow_dtype",
+      "description":"Depth of snow data type"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Degree day coefficient data type",
+      "key":"c0_dtype",
+      "description":"Degree day coefficient data type"
+    },
+    {
+      "value":{
+        "default":"site",
+        "units":"-",
+        "type":"string"
+      },
+      "visible":false,
+      "name":"File prefix for the study site",
+      "key":"site_prefix",
+      "description":"File prefix for the study site"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Depth of snow water equivalent (SWE) data type",
+      "key":"h0_swe_dtype",
+      "description":"Depth of snow water equivalent (SWE) data type"
+    },
+    {
+      "value":{
+        "default":100,
+        "units":"-",
+        "range":{
+          "max":100000,
+          "min":1
+        },
+        "type":"int"
+      },
+      "visible":false,
+      "name":"Number of time steps",
+      "key":"n_steps",
+      "description":"Number of time steps"
+    },
+    {
+      "value":{
+        "default":"float",
+        "units":"-",
+        "type":"choice",
+        "choices":[
+          "float",
+          "int",
+          "long",
+          "string"
+        ]
+      },
+      "visible":false,
+      "name":"Density of snow data type",
+      "key":"rho_snow_dtype",
+      "description":"Density of snow data type"
+    }
+  ]
+}

--- a/war/data/snow_degree_day.json
+++ b/war/data/snow_degree_day.json
@@ -45,6 +45,7 @@
         "type":"int"
       },
       "visible":true,
+      "global":true,
       "name":"Simulation run time",
       "key":"run_duration",
       "description":"Simulation run time"


### PR DESCRIPTION
In this PR, we introduce a **global** parameter attribute. A global parameter is only displayed in the driver component. All "passenger" (ugh, @mcflugen) components use the value of the global component, but it's not displayed with their parameters. A good example is `run_duration`: we want all components in a model to run for the same amount of time, so we only display this parameter in the driver. This makes it easier for the user since they don't have to set the run duration on each component of the model.

Notable changes:
* Added ParameterJSO#isGlobal() + unit tests
* ParameterTable#loadTable(String) is now ParameterTable#loadTable(ComponentCell)