### PR TITLE
Style modifications

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/Constants.java
+++ b/src/edu/colorado/csdms/wmt/client/Constants.java
@@ -125,7 +125,7 @@ public class Constants {
   public static Integer DEFAULT_MODEL_ID = -1;
 
   // The number of characters to display in a ComponentCell.
-  public static Integer TRIM = 12;
+  public static Integer TRIM = 14;
 
   // Unicode representation.
   public static String ELLIPSIS = "\u2026";

--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -239,10 +239,9 @@ body, table td, select, button {
 /* A ComponentCell that displays a component's parameters. */
 .wmt-ComponentCell-showingParameters:after {
   position: absolute;
-  right: -20px;
+  right: -18px;
   top: 2px;
   font-family: "FontAwesome";
-  /* padding: 3px; */
   content: "\f0ad"; /* fa-wrench */
   color: colorDark;
 }
@@ -261,9 +260,11 @@ body, table td, select, button {
 }
 .wmt-ComponentCell-NameCell-alias:after {
    font-family: "FontAwesome";
-   padding: 3px;
+   position: absolute;
+   right: -18px;
+   bottom: 2px;
    content: "\f112"; /* fa-reply */
-   color: colorLight;
+   color: colorDark;
 }
 
 /* For the menuCell inside the ComponentCell. */

--- a/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
@@ -28,6 +28,7 @@ import edu.colorado.csdms.wmt.client.ui.panel.ParameterActionPanel;
  */
 public class ParameterTable extends FlexTable {
 
+  private static final String CELL_WIDTH = "220px"; // fragile, should calculate
   public DataManager data;
   private String componentId; // the id of the displayed component
   private ComponentCell cell; // the corresponding cell in the ModelTree
@@ -157,6 +158,9 @@ public class ParameterTable extends FlexTable {
       valueCell.getWidget(0).addStyleDependentName("upload");
       this.setWidget(tableRowIndex, 1, valueCell);
       this.setWidget(tableRowIndex, 2, selections.get(0));
+      this.getFlexCellFormatter().setHorizontalAlignment(tableRowIndex, 1,
+        HasHorizontalAlignment.ALIGN_RIGHT);
+      this.getFlexCellFormatter().setWidth(tableRowIndex, 2, CELL_WIDTH);
       valueCell.addDomHandler(new SelectionChangeHandler(tableRowIndex,
           selections), ChangeEvent.getType());
     }


### PR DESCRIPTION
Three improvements in this PR:

* The selector droplist stays put when the ParametersPanel is resized.
* The "showing parameters" and "alias" icons are positioned as siblings outside of a ComponentCell.
* The space vacated by the "alias" icon can be used to show more characters in a ComponentCell.