### PR TITLE
Prompt user only once to save model when uploading file

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/control/DataTransfer.java
+++ b/src/edu/colorado/csdms/wmt/client/control/DataTransfer.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.control;
 
 import java.sql.Date;
@@ -1352,12 +1329,8 @@ public class DataTransfer {
       }
 
       // Show metadata for the first model in the droplist.
-      String selectedModelName =
-          droplist.getItemText(droplist.getSelectedIndex());
-      data.getPerspective().getOpenDialogBox().getMetadataPanel().setOwner(
-          data.findModel(selectedModelName).getOwner());
-      data.getPerspective().getOpenDialogBox().getMetadataPanel().setDate(
-          data.findModel(selectedModelName).getDate());
+      String modelName = droplist.getItemText(droplist.getSelectedIndex());
+      data.getPerspective().getOpenDialogBox().populateMetadataPanel(modelName);
     }
 
     /*
@@ -1369,8 +1342,7 @@ public class DataTransfer {
         for (int i = 0; i < jso.getIds().length(); i++) {
 
           GWT.log("Entry : " + entry.getValue().getId());
-          GWT.log("JSO : " + jso.getIds().get(i)); // fails in dev mode, see
-// LabelQueryJSOTest#testGetIds
+          GWT.log("JSO : " + jso.getIds().get(i)); // fails in dev mode, see LabelQueryJSOTest#testGetIds
 
           if (entry.getValue().getId() == jso.getIds().get(i)) {
             entry.getValue().isSelected(true);

--- a/src/edu/colorado/csdms/wmt/client/ui/cell/FileCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/FileCell.java
@@ -12,6 +12,7 @@ import com.google.gwt.user.client.ui.FormPanel.SubmitCompleteEvent;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.ListBox;
 
+import edu.colorado.csdms.wmt.client.Constants;
 import edu.colorado.csdms.wmt.client.control.DataURL;
 import edu.colorado.csdms.wmt.client.data.ParameterJSO;
 import edu.colorado.csdms.wmt.client.ui.ParameterTable;
@@ -98,7 +99,11 @@ public class FileCell extends HorizontalPanel {
     public void onClick(ClickEvent event) {
 
       ParameterTable pt = (ParameterTable) parent.getParent();
-      if (!pt.data.modelIsSaved()) {
+
+      // Get the id of the model this file belongs to.
+      Integer modelId = pt.data.getMetadata().getId();
+
+      if (modelId == Constants.DEFAULT_MODEL_ID) {
         String msg =
             "The model must be saved to the server"
                 + " before files can be uploaded.";
@@ -108,10 +113,7 @@ public class FileCell extends HorizontalPanel {
 
       uploadBox = new UploadDialogBox();
       uploadBox.setText("Upload File...");
-
-      // Get the id of the model this file belongs to.
-      String modelId = ((Integer) pt.data.getMetadata().getId()).toString(); 
-      uploadBox.getHidden().setValue(modelId);
+      uploadBox.getHidden().setValue(modelId.toString());
 
       // Where the form is to be submitted.
       uploadBox.getForm().setAction(DataURL.uploadFile(pt.data));

--- a/src/edu/colorado/csdms/wmt/client/ui/dialog/OpenDialogBox.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/dialog/OpenDialogBox.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.dialog;
 
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -78,9 +55,7 @@ public class OpenDialogBox extends DialogBox {
       @Override
       public void onChange(ChangeEvent event) {
         ListBox droplist = (ListBox) event.getSource();
-        String modelName = droplist.getItemText(droplist.getSelectedIndex());
-        metadataPanel.setOwner(OpenDialogBox.this.data.findModel(modelName).getOwner());
-        metadataPanel.setDate(OpenDialogBox.this.data.findModel(modelName).getDate());
+        populateMetadataPanel(droplist.getItemText(droplist.getSelectedIndex()));
       }
     });
 
@@ -130,6 +105,18 @@ public class OpenDialogBox extends DialogBox {
     DataTransfer.queryModelLabels(data, labelsMenu.getSelectedLabelIds());
   }
   
+  /**
+   * A helper that loads information into the MetadataPanel of the
+   * {@link OpenDialogBox}.
+   * 
+   * @param modelName the name of the saved model displayed in the dialog box.
+   */
+  public void populateMetadataPanel(String modelName) {
+    metadataPanel.setOwner(data.findModel(modelName).getOwner());
+    metadataPanel.setDate(data.findModel(modelName).getDate());
+    metadataPanel.setId(data.findModel(modelName).getId());
+  }
+
   public DroplistPanel getDroplistPanel() {
     return droplistPanel;
   }

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelOpenHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelOpenHandler.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- * 
- * Copyright (c) 2014 mcflugen
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package edu.colorado.csdms.wmt.client.ui.handler;
 
 import com.google.gwt.event.dom.client.ClickEvent;

--- a/src/edu/colorado/csdms/wmt/client/ui/panel/MetadataPanel.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/panel/MetadataPanel.java
@@ -4,8 +4,10 @@ import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 
+import edu.colorado.csdms.wmt.client.Constants;
+
 /**
- * Displays the owner and creation date of a model.
+ * Displays the owner, creation date, and internal id of a model.
  * 
  * @author Mark Piper (mark.piper@colorado.edu)
  */
@@ -14,6 +16,7 @@ public class MetadataPanel extends HorizontalPanel {
   private Grid grid;
   private String owner = "";
   private String date = "";
+  private Integer id = Constants.DEFAULT_MODEL_ID;
   
   public MetadataPanel() {
 
@@ -21,14 +24,18 @@ public class MetadataPanel extends HorizontalPanel {
     this.setSpacing(5); // px
     this.setHorizontalAlignment(HasHorizontalAlignment.ALIGN_CENTER);
     
-    grid = new Grid(2, 2);
+    grid = new Grid(3, 2);
     grid.setHTML(0, 0, "owner:");
     grid.setHTML(1, 0, "creation date:");
+    grid.setHTML(2, 0, "id:");
     grid.setHTML(0, 1, owner);
     grid.setHTML(1, 1, date);
+    grid.setHTML(2, 1, id.toString());
     grid.getCellFormatter().setHorizontalAlignment(0, 0,
         HasHorizontalAlignment.ALIGN_RIGHT);
     grid.getCellFormatter().setHorizontalAlignment(1, 0,
+        HasHorizontalAlignment.ALIGN_RIGHT);
+    grid.getCellFormatter().setHorizontalAlignment(2, 0,
         HasHorizontalAlignment.ALIGN_RIGHT);
     
     this.add(grid);
@@ -48,5 +55,13 @@ public class MetadataPanel extends HorizontalPanel {
 
   public void setDate(String date) {
     grid.setHTML(1, 1, date);
+  }
+
+  public String getId() {
+    return grid.getText(2, 1);
+  }
+
+  public void setId(Integer id) {
+    grid.setHTML(2, 1, id.toString());
   }
 }


### PR DESCRIPTION
Instead of prompting the user to save the model every time an upload is performed, check whether the model has been previously saved to the server. If so, don't nag.