### PR TITLE
Fix issue where "Save as" on public model doesn't transfer uploaded files

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelSaveHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelSaveHandler.java
@@ -60,7 +60,8 @@ public class ModelActionPanelSaveHandler implements ClickHandler {
             entry.getValue().isSelected(false);
           }
         }
-        showSaveDialogBox(Constants.MODELS_NEW_PATH);
+        data.getMetadata().setOwner(data.security.getWmtUsername());
+        showSaveDialogBox(Constants.MODELS_SAVEAS_PATH);
       }
     } else {
       if (isSaveAs) {


### PR DESCRIPTION
This is a critical bug bug because it effects the way @iovereem uses WMT in classes -- she creates public models, which she shares with the students. Files are now transferred correctly.

This fixes #69.