### PR TITLE
Add new "subheading" parameter type

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -353,6 +353,7 @@ body, table td, select, button {
 .wmt-ParameterDescription {
    margin: 0 1em 0 25px; /* top right bottom left */
    color: colorMediumDark;
+   min-height: 38px; /* accomodate subheading type */
 }
 .wmt-ParameterDescription-group {
    padding-left: 20px;

--- a/src/edu/colorado/csdms/wmt/client/ui/cell/ValueCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/ValueCell.java
@@ -39,6 +39,8 @@ public class ValueCell extends HorizontalPanel {
       this.add(new IntegerCell(this));
     } else if (isFloat()) {
       this.add(new DoubleCell(this));
+    } else if (isSubheading()) {
+      ;  // do nothing
     } else {
       this.add(new TextCell(this));
     }
@@ -99,5 +101,14 @@ public class ValueCell extends HorizontalPanel {
    */
   public Boolean isFloat() {
     return cellType.matches("float");
+  }
+
+  /**
+   * States whether parameter is of type "subheading".
+   *
+   * @return true if the parameter type is "subheading"
+   */
+  public Boolean isSubheading() {
+    return cellType.matches("subheading");
   }
 }

--- a/war/data/anuga.json
+++ b/war/data/anuga.json
@@ -18,6 +18,63 @@
       "visible":true,
       "key":"_run_duration",
       "description":"Simulation run time"
+    },
+    {
+      "key":"mstmip_heading",
+      "name":"MsTMIP_1",
+      "description":"MsTMIP models",
+      "value":{
+        "type":"subheading",
+        "default":""
+      }
+    },
+    {
+      "key":"starting_mean_annual_temperature",
+      "name":"Starting mean annual temperature",
+      "description":"Monthly mean annual temperature",
+      "group":{
+        "name":"mean_annual_temperature",
+        "leader":true,
+        "members":3
+      },
+      "value":{
+        "type":"subheading",
+        "default":""
+      }
+    },
+    {
+      "key":"january_temperature_mean",
+      "name":"Mean January temperature",
+      "description":"Mean temperature for January",
+      "group":{
+        "name":"mean_annual_temperature"
+      },
+      "value":{
+        "type":"float",
+        "default":19.14,
+        "range":{
+          "min":0.0,
+          "max":100.0
+        },
+        "units":"deg C"
+      }
+    },
+    {
+      "key":"february_temperature_mean",
+      "name":"Mean February temperature",
+      "description":"Mean temperature for February",
+      "group":{
+        "name":"mean_annual_temperature"
+      },
+      "value":{
+        "type":"float",
+        "default":18.85,
+        "range":{
+          "min":0.0,
+          "max":100.0
+        },
+        "units":"deg C"
+      }
     }
   ],
   "name":"AnugaSed",


### PR DESCRIPTION
The "subheading" parameter type displays a description, but no value, in the WMT client ParameterTable.