### PR TITLE
Create overview type

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/WMT.css
+++ b/src/edu/colorado/csdms/wmt/client/WMT.css
@@ -355,6 +355,10 @@ body, table td, select, button {
    color: colorMediumDark;
    min-height: 38px; /* accomodate subheading type */
 }
+.wmt-ParameterDescription-overview {
+   margin-left: 0px;
+   margin-bottom: 5px;
+}
 .wmt-ParameterDescription-group {
    padding-left: 20px;
    vertical-align: middle;

--- a/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/ParameterTable.java
@@ -123,6 +123,14 @@ public class ParameterTable extends FlexTable {
       return;
     }
 
+    // If the parameter is an overview, display it, then return.
+    if (parameter.getValue().getType().matches("overview")) {
+      this.setWidget(tableRowIndex, 0, new DescriptionCell(parameter));
+      this.getFlexCellFormatter().setColSpan(tableRowIndex, 0, 3);
+      tableRowIndex++;
+      return;
+    }
+
     // The basic setup: display the parameter's description and value.
     DescriptionCell descriptionCell = new DescriptionCell(parameter);
     ValueCell valueCell = new ValueCell(parameter);

--- a/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/cell/DescriptionCell.java
@@ -40,6 +40,9 @@ public class DescriptionCell extends HTML {
     if (parameter.isGroupLeader()) {
       this.addStyleDependentName("groupLeader");
     }
+    if (parameter.getValue().getType().matches("overview")) {
+      this.addStyleDependentName("overview");
+    }
   }
 
   public ArrayList<Integer> getGroupRows() {

--- a/war/data/anuga.json
+++ b/war/data/anuga.json
@@ -4,6 +4,24 @@
   ],
   "parameters":[
     {
+      "key":"separator",
+      "name":"foobar",
+      "description":"Globals",
+      "value":{
+        "type":"string",
+        "default":""
+      }
+    },
+    {
+      "key":"globals_overview",
+      "name":"foobar",
+      "description":"Select one or more <b>CMIP5-compatible</b> models for benchmarking with <a href='https://www.ilamb.org'>ILAMB</a>. This is a very long overview. I want to see how line spacing is handled. Also, is there a way to break an attribute of a JSON object over several lines? I mean, I am way out here.",
+      "value":{
+        "type":"overview",
+        "default":""
+      }
+    },
+    {
       "name":"Simulation run time",
       "global":true,
       "value":{


### PR DESCRIPTION
This PR implements a new type, "overview", that allows the display of explanatory text in the ParameterTable of a component in the WMT client. The overview uses a styled DescriptionCell that spans the ParameterTable. I've included a sample of using an overview in **anuga.json**.