### PR TITLE
Update JDK version in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 
 sudo: false
 
-before_script:
+install:
   - wget http://csdms.colorado.edu/pub/tools/gwt/gwt-2.5.1.zip
   - unzip -qq gwt-2.5.1.zip
   - export GWT_HOME=$PWD/gwt-2.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - openjdk7
 
 sudo: false
 


### PR DESCRIPTION
Oracle JDK 7 is no longer supported on Travis, so I switched to JDK 8. Also test against OpenJDK7. 