### PR TITLE
Reload components in wmt-client

### DIFF
--- a/src/edu/colorado/csdms/wmt/client/Constants.java
+++ b/src/edu/colorado/csdms/wmt/client/Constants.java
@@ -157,6 +157,7 @@ public class Constants {
   public static String FA_RARROW = "<i class='fa fa-arrow-right'></i> ";
   public static String FA_BOLT = "<i class='fa fa-bolt'></i> ";
   public static String FA_LINK = "<i class='fa fa-external-link'></i> ";
+  public static String FA_RELOAD = "<i class='fa fa-refresh fa-fw'></i> ";
 
   // Panel titles.
   public static String TITLE_TOP_PANEL = "The CSDMS Web Modeling Tool";
@@ -179,6 +180,7 @@ public class Constants {
   public static String COMPONENT_INFO =
       "View information about this component.";
   public static String COMPONENT_INFO_1 = "View information about a component.";
+  public static String COMPONENT_RELOAD = "Reload components from the server.";
   public static String COMPONENT_CLOSE =
       "Remove this component (and its children, if any) from the model.";
   public static String PARAMETER_RESET = "Reset all parameters for this"

--- a/src/edu/colorado/csdms/wmt/client/control/DataManager.java
+++ b/src/edu/colorado/csdms/wmt/client/control/DataManager.java
@@ -163,6 +163,20 @@ public class DataManager {
   }
 
   /**
+   * Replaces a component in DataManager's stored ArrayList of components.
+   *
+   * @param component the replacement component, a {@link ComponentJSO}
+   */
+  public void replaceComponent(ComponentJSO component) {
+    for (int i = 0; i < components.size(); i++) {
+      if (components.get(i).getId().matches(component.getId())) {
+        components.set(i, component);
+        return;
+      }
+    }
+  }
+
+  /**
    * Returns the <em>all</em> the components in the ArrayList of
    * {@link ComponentJSO} objects.
    */

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelReloadHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelReloadHandler.java
@@ -1,0 +1,37 @@
+package edu.colorado.csdms.wmt.client.ui.handler;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.Window;
+
+import edu.colorado.csdms.wmt.client.control.DataManager;
+
+/**
+ * Handles click on the "Reload" button in the ModelActionPanel. It calls
+ * DataTransfer.getComponent to fetch all components from the server.
+ * 
+ * @author Mark Piper (mark.piper@colorado.edu)
+ */
+
+public class ModelActionPanelReloadHandler implements ClickHandler {
+
+  private DataManager data;
+
+  /**
+   * Creates a new instance of {@link ModelActionPanelReloadHandler}.
+   * 
+   * @param data the DataManager object for the WMT session
+   */
+  public ModelActionPanelReloadHandler(DataManager data) {
+    this.data = data;
+  }
+
+  @Override
+  public void onClick(ClickEvent event) {
+
+    // Hide the MoreActionsMenu.
+    data.getPerspective().getActionButtonPanel().getMoreMenu().hide();
+
+    Window.alert("Reload!");
+  }
+}

--- a/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelReloadHandler.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/handler/ModelActionPanelReloadHandler.java
@@ -1,10 +1,13 @@
 package edu.colorado.csdms.wmt.client.ui.handler;
 
+import java.util.Iterator;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.Window;
 
 import edu.colorado.csdms.wmt.client.control.DataManager;
+import edu.colorado.csdms.wmt.client.control.DataTransfer;
 
 /**
  * Handles click on the "Reload" button in the ModelActionPanel. It calls
@@ -32,6 +35,12 @@ public class ModelActionPanelReloadHandler implements ClickHandler {
     // Hide the MoreActionsMenu.
     data.getPerspective().getActionButtonPanel().getMoreMenu().hide();
 
-    Window.alert("Reload!");
+    // Reload each component from the original list.
+    for (String componentId : data.componentIdList) {
+      DataTransfer.reloadComponent(data, componentId);
+    }
+
+    // Not really, since the above is asynchronous.
+    Window.alert("Components reloaded.");
   }
 }

--- a/src/edu/colorado/csdms/wmt/client/ui/menu/MoreActionsMenu.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/menu/MoreActionsMenu.java
@@ -10,6 +10,7 @@ import edu.colorado.csdms.wmt.client.Constants;
 import edu.colorado.csdms.wmt.client.control.DataManager;
 import edu.colorado.csdms.wmt.client.ui.handler.ModelActionPanelDeleteHandler;
 import edu.colorado.csdms.wmt.client.ui.handler.ModelActionPanelHelpHandler;
+import edu.colorado.csdms.wmt.client.ui.handler.ModelActionPanelReloadHandler;
 import edu.colorado.csdms.wmt.client.ui.handler.ModelActionPanelSaveHandler;
 
 /**

--- a/src/edu/colorado/csdms/wmt/client/ui/menu/MoreActionsMenu.java
+++ b/src/edu/colorado/csdms/wmt/client/ui/menu/MoreActionsMenu.java
@@ -108,6 +108,13 @@ public class MoreActionsMenu extends PopupPanel {
       }
     });
 
+    // Reload components
+    HTML reloadButton = new HTML(Constants.FA_RELOAD + "Reload components");
+    reloadButton.setStyleName("wmt-PopupPanelItem");
+    reloadButton.setTitle(Constants.COMPONENT_RELOAD);
+    reloadButton.addClickHandler(new ModelActionPanelReloadHandler(data));
+    menu.add(reloadButton);
+
     // Run status
     final HTML statusButton = new HTML(Constants.FA_STATUS + "View run status");
     statusButton.setStyleName("wmt-PopupPanelItem");


### PR DESCRIPTION
This PR gives the user the ability to reload component metadata from the server into the client through a new *Reload components* button and its associated callbacks.